### PR TITLE
Fix allowed types in PHP `settype()`

### DIFF
--- a/src/ObjectSerializer.php
+++ b/src/ObjectSerializer.php
@@ -331,7 +331,7 @@ class ObjectSerializer
         }
 
         /** @psalm-suppress ParadoxicalCondition */
-        if (in_array($class, ['\DateTime', '\SplFileObject', 'array', 'bool', 'boolean', 'byte', 'double', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)) {
+        if (in_array($class, ['bool', 'boolean', 'int', 'integer', 'float', 'double', 'string', 'array', 'object', 'null'], true)) {
             settype($data, $class);
             return $data;
         }


### PR DESCRIPTION
Hey! Thanks for creating a PHP client.

I'm integrating this in a (Laravel) project for the simple use case to download a document from a document id.

Implementing it was really simple. However, every time I got the following error:

```
settype(): Argument #2 ($type) must be a valid type
```

The error pointed to the following location:

```php
/** @psalm-suppress ParadoxicalCondition */
if (in_array($class, ['\DateTime', '\SplFileObject', 'array', 'bool', 'boolean', 'byte', 'double', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)) {
    settype($data, $class);
    return $data;
}

if ($class === '\SplFileObject') {
    // ..
```

I took a look at the [PHP documentation for `settype()`](https://www.php.net/manual/en/function.settype.php) and I noticed that you are allowing too many types in the `if` condition.

You can basically also see that this `in_array` doesn't make sense, because after the erroneous condition, we have another condition that checks whether the result is an `\SplFileObject`. 

I updated the `if`-condition to only accept the types that PHP allows and I confirmed in my project that this code works correctly!
