### PR TITLE
Add attribute ReturnTypeWillChange

### DIFF
--- a/src/Model/APILogDetailsResponse.php
+++ b/src/Model/APILogDetailsResponse.php
@@ -683,6 +683,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -695,6 +696,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -708,6 +710,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -724,6 +727,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -736,6 +740,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -764,5 +769,3 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/APILogDetailsResponse.php
+++ b/src/Model/APILogDetailsResponse.php
@@ -683,7 +683,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -696,7 +696,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -710,7 +710,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -727,7 +727,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -740,7 +740,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/APILogListResponse.php
+++ b/src/Model/APILogListResponse.php
@@ -233,7 +233,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -246,7 +246,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -260,7 +260,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -277,7 +277,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -290,7 +290,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/APILogListResponse.php
+++ b/src/Model/APILogListResponse.php
@@ -233,6 +233,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +246,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +260,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +277,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +290,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -314,5 +319,3 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/APILogListResponseResults.php
+++ b/src/Model/APILogListResponseResults.php
@@ -353,7 +353,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -366,7 +366,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -380,7 +380,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -397,7 +397,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -410,7 +410,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/APILogListResponseResults.php
+++ b/src/Model/APILogListResponseResults.php
@@ -353,6 +353,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -365,6 +366,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -378,6 +380,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -394,6 +397,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -406,6 +410,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -434,5 +439,3 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/ContactCreateRequest.php
+++ b/src/Model/ContactCreateRequest.php
@@ -506,6 +506,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -518,6 +519,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -531,6 +533,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -547,6 +550,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -559,6 +563,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -587,5 +592,3 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/ContactCreateRequest.php
+++ b/src/Model/ContactCreateRequest.php
@@ -506,7 +506,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -519,7 +519,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -533,7 +533,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -550,7 +550,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -563,7 +563,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/ContactDetailsResponse.php
+++ b/src/Model/ContactDetailsResponse.php
@@ -533,6 +533,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -545,6 +546,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -558,6 +560,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -574,6 +577,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -586,6 +590,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -614,5 +619,3 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/ContactDetailsResponse.php
+++ b/src/Model/ContactDetailsResponse.php
@@ -533,7 +533,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -546,7 +546,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -560,7 +560,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -577,7 +577,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -590,7 +590,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/ContactListResponse.php
+++ b/src/Model/ContactListResponse.php
@@ -233,7 +233,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -246,7 +246,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -260,7 +260,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -277,7 +277,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -290,7 +290,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/ContactListResponse.php
+++ b/src/Model/ContactListResponse.php
@@ -233,6 +233,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +246,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +260,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +277,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +290,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -314,5 +319,3 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/ContactUpdateRequest.php
+++ b/src/Model/ContactUpdateRequest.php
@@ -503,7 +503,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -516,7 +516,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -530,7 +530,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -547,7 +547,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -560,7 +560,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/ContactUpdateRequest.php
+++ b/src/Model/ContactUpdateRequest.php
@@ -503,6 +503,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -515,6 +516,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -528,6 +530,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -544,6 +547,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -556,6 +560,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -584,5 +589,3 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/ContentLibraryItemListResponse.php
+++ b/src/Model/ContentLibraryItemListResponse.php
@@ -233,7 +233,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -246,7 +246,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -260,7 +260,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -277,7 +277,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -290,7 +290,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/ContentLibraryItemListResponse.php
+++ b/src/Model/ContentLibraryItemListResponse.php
@@ -233,6 +233,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +246,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +260,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +277,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +290,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -314,5 +319,3 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/ContentLibraryItemListResponseResults.php
+++ b/src/Model/ContentLibraryItemListResponseResults.php
@@ -353,7 +353,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -366,7 +366,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -380,7 +380,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -397,7 +397,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -410,7 +410,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/ContentLibraryItemListResponseResults.php
+++ b/src/Model/ContentLibraryItemListResponseResults.php
@@ -353,6 +353,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -365,6 +366,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -378,6 +380,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -394,6 +397,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -406,6 +410,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -434,5 +439,3 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/ContentLibraryItemResponse.php
+++ b/src/Model/ContentLibraryItemResponse.php
@@ -623,6 +623,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -635,6 +636,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -648,6 +650,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -664,6 +667,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -676,6 +680,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -704,5 +709,3 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/ContentLibraryItemResponse.php
+++ b/src/Model/ContentLibraryItemResponse.php
@@ -623,7 +623,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -636,7 +636,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -650,7 +650,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -667,7 +667,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -680,7 +680,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/ContentLibraryItemResponseCreatedBy.php
+++ b/src/Model/ContentLibraryItemResponseCreatedBy.php
@@ -353,7 +353,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -366,7 +366,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -380,7 +380,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -397,7 +397,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -410,7 +410,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/ContentLibraryItemResponseCreatedBy.php
+++ b/src/Model/ContentLibraryItemResponseCreatedBy.php
@@ -353,6 +353,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -365,6 +366,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -378,6 +380,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -394,6 +397,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -406,6 +410,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -434,5 +439,3 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentAttachmentResponse.php
+++ b/src/Model/DocumentAttachmentResponse.php
@@ -323,7 +323,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -336,7 +336,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -350,7 +350,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -367,7 +367,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -380,7 +380,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentAttachmentResponse.php
+++ b/src/Model/DocumentAttachmentResponse.php
@@ -323,6 +323,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -335,6 +336,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -348,6 +350,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -364,6 +367,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -376,6 +380,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -404,5 +409,3 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentAttachmentResponseCreatedBy.php
+++ b/src/Model/DocumentAttachmentResponseCreatedBy.php
@@ -353,7 +353,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -366,7 +366,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -380,7 +380,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -397,7 +397,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -410,7 +410,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentAttachmentResponseCreatedBy.php
+++ b/src/Model/DocumentAttachmentResponseCreatedBy.php
@@ -353,6 +353,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -365,6 +366,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -378,6 +380,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -394,6 +397,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -406,6 +410,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -434,5 +439,3 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentCreateByPdfRequest.php
+++ b/src/Model/DocumentCreateByPdfRequest.php
@@ -419,6 +419,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -431,6 +432,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -444,6 +446,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -460,6 +463,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -472,6 +476,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -500,5 +505,3 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentCreateByPdfRequest.php
+++ b/src/Model/DocumentCreateByPdfRequest.php
@@ -419,7 +419,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -432,7 +432,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -446,7 +446,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -463,7 +463,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -476,7 +476,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentCreateByTemplateRequest.php
+++ b/src/Model/DocumentCreateByTemplateRequest.php
@@ -542,7 +542,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -555,7 +555,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -569,7 +569,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -586,7 +586,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -599,7 +599,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentCreateByTemplateRequest.php
+++ b/src/Model/DocumentCreateByTemplateRequest.php
@@ -542,6 +542,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -554,6 +555,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -567,6 +569,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -583,6 +586,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -595,6 +599,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -623,5 +628,3 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentCreateByTemplateRequestContentLibraryItems.php
+++ b/src/Model/DocumentCreateByTemplateRequestContentLibraryItems.php
@@ -326,6 +326,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -338,6 +339,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -351,6 +353,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -367,6 +370,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -379,6 +383,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -407,5 +412,3 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentCreateByTemplateRequestContentLibraryItems.php
+++ b/src/Model/DocumentCreateByTemplateRequestContentLibraryItems.php
@@ -326,7 +326,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -339,7 +339,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -353,7 +353,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -370,7 +370,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -383,7 +383,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentCreateByTemplateRequestContentPlaceholders.php
+++ b/src/Model/DocumentCreateByTemplateRequestContentPlaceholders.php
@@ -266,6 +266,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -278,6 +279,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -291,6 +293,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -307,6 +310,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -319,6 +323,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -347,5 +352,3 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentCreateByTemplateRequestContentPlaceholders.php
+++ b/src/Model/DocumentCreateByTemplateRequestContentPlaceholders.php
@@ -266,7 +266,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -279,7 +279,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -293,7 +293,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -310,7 +310,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -323,7 +323,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentCreateByTemplateRequestImages.php
+++ b/src/Model/DocumentCreateByTemplateRequestImages.php
@@ -269,7 +269,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -282,7 +282,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -296,7 +296,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -313,7 +313,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -326,7 +326,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentCreateByTemplateRequestImages.php
+++ b/src/Model/DocumentCreateByTemplateRequestImages.php
@@ -269,6 +269,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -281,6 +282,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -294,6 +296,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -310,6 +313,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -322,6 +326,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -350,5 +355,3 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentCreateByTemplateRequestRecipients.php
+++ b/src/Model/DocumentCreateByTemplateRequestRecipients.php
@@ -356,6 +356,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -368,6 +369,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -381,6 +383,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -397,6 +400,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -409,6 +413,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -437,5 +442,3 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentCreateByTemplateRequestRecipients.php
+++ b/src/Model/DocumentCreateByTemplateRequestRecipients.php
@@ -356,7 +356,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -369,7 +369,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -383,7 +383,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -400,7 +400,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -413,7 +413,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentCreateByTemplateRequestTokens.php
+++ b/src/Model/DocumentCreateByTemplateRequestTokens.php
@@ -269,6 +269,7 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -281,6 +282,7 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -294,6 +296,7 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -310,6 +313,7 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -322,6 +326,7 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -350,5 +355,3 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentCreateLinkRequest.php
+++ b/src/Model/DocumentCreateLinkRequest.php
@@ -266,6 +266,7 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -278,6 +279,7 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -291,6 +293,7 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -307,6 +310,7 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -319,6 +323,7 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -347,5 +352,3 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentCreateLinkResponse.php
+++ b/src/Model/DocumentCreateLinkResponse.php
@@ -263,6 +263,7 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -275,6 +276,7 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -288,6 +290,7 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -304,6 +307,7 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -316,6 +320,7 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -344,5 +349,3 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentCreateRequest.php
+++ b/src/Model/DocumentCreateRequest.php
@@ -623,6 +623,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -635,6 +636,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -648,6 +650,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -664,6 +667,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -676,6 +680,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -704,5 +709,3 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentCreateRequestContentLibraryItems.php
+++ b/src/Model/DocumentCreateRequestContentLibraryItems.php
@@ -326,6 +326,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -338,6 +339,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -351,6 +353,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -367,6 +370,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -379,6 +383,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -407,5 +412,3 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentCreateRequestContentLibraryItems.php
+++ b/src/Model/DocumentCreateRequestContentLibraryItems.php
@@ -326,7 +326,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -339,7 +339,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -353,7 +353,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -370,7 +370,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -383,7 +383,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentCreateRequestContentPlaceholders.php
+++ b/src/Model/DocumentCreateRequestContentPlaceholders.php
@@ -263,6 +263,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -275,6 +276,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -288,6 +290,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -304,6 +307,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -316,6 +320,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -344,5 +349,3 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentCreateRequestContentPlaceholders.php
+++ b/src/Model/DocumentCreateRequestContentPlaceholders.php
@@ -263,7 +263,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -276,7 +276,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -290,7 +290,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -307,7 +307,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -320,7 +320,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentCreateRequestImages.php
+++ b/src/Model/DocumentCreateRequestImages.php
@@ -269,6 +269,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -281,6 +282,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -294,6 +296,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -310,6 +313,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -322,6 +326,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -350,5 +355,3 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentCreateRequestImages.php
+++ b/src/Model/DocumentCreateRequestImages.php
@@ -269,7 +269,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -282,7 +282,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -296,7 +296,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -313,7 +313,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -326,7 +326,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentCreateRequestRecipients.php
+++ b/src/Model/DocumentCreateRequestRecipients.php
@@ -356,6 +356,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -368,6 +369,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -381,6 +383,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -397,6 +400,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -409,6 +413,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -437,5 +442,3 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentCreateResponse.php
+++ b/src/Model/DocumentCreateResponse.php
@@ -473,6 +473,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -485,6 +486,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -498,6 +500,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -514,6 +517,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -526,6 +530,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -554,5 +559,3 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentCreateResponseLinks.php
+++ b/src/Model/DocumentCreateResponseLinks.php
@@ -293,6 +293,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -305,6 +306,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -318,6 +320,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -334,6 +337,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -346,6 +350,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -374,5 +379,3 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentDetailsResponse.php
+++ b/src/Model/DocumentDetailsResponse.php
@@ -803,7 +803,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -816,7 +816,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -830,7 +830,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -847,7 +847,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -860,7 +860,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentDetailsResponse.php
+++ b/src/Model/DocumentDetailsResponse.php
@@ -803,6 +803,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -815,6 +816,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -828,6 +830,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -844,6 +847,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -856,6 +860,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -884,5 +889,3 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentDetailsResponseCreatedBy.php
+++ b/src/Model/DocumentDetailsResponseCreatedBy.php
@@ -383,6 +383,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -395,6 +396,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -408,6 +410,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -424,6 +427,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -436,6 +440,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -464,5 +469,3 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentDetailsResponseCreatedBy.php
+++ b/src/Model/DocumentDetailsResponseCreatedBy.php
@@ -383,7 +383,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -396,7 +396,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -410,7 +410,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -427,7 +427,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -440,7 +440,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentDetailsResponseGrandTotal.php
+++ b/src/Model/DocumentDetailsResponseGrandTotal.php
@@ -263,6 +263,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -275,6 +276,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -288,6 +290,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -304,6 +307,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -316,6 +320,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -344,5 +349,3 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentDetailsResponseGrandTotal.php
+++ b/src/Model/DocumentDetailsResponseGrandTotal.php
@@ -263,7 +263,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -276,7 +276,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -290,7 +290,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -307,7 +307,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -320,7 +320,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentDetailsResponseLinkedObjects.php
+++ b/src/Model/DocumentDetailsResponseLinkedObjects.php
@@ -323,7 +323,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -336,7 +336,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -350,7 +350,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -367,7 +367,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -380,7 +380,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentDetailsResponseLinkedObjects.php
+++ b/src/Model/DocumentDetailsResponseLinkedObjects.php
@@ -323,6 +323,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -335,6 +336,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -348,6 +350,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -364,6 +367,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -376,6 +380,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -404,5 +409,3 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentDetailsResponseRecipients.php
+++ b/src/Model/DocumentDetailsResponseRecipients.php
@@ -535,7 +535,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -548,7 +548,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -562,7 +562,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -579,7 +579,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -592,7 +592,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentDetailsResponseRecipients.php
+++ b/src/Model/DocumentDetailsResponseRecipients.php
@@ -535,6 +535,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -547,6 +548,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -560,6 +562,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -576,6 +579,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -588,6 +592,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -616,5 +621,3 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentDetailsResponseTemplate.php
+++ b/src/Model/DocumentDetailsResponseTemplate.php
@@ -263,6 +263,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -275,6 +276,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -288,6 +290,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -304,6 +307,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -316,6 +320,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -344,5 +349,3 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentDetailsResponseTemplate.php
+++ b/src/Model/DocumentDetailsResponseTemplate.php
@@ -263,7 +263,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -276,7 +276,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -290,7 +290,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -307,7 +307,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -320,7 +320,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentListResponse.php
+++ b/src/Model/DocumentListResponse.php
@@ -233,7 +233,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -246,7 +246,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -260,7 +260,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -277,7 +277,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -290,7 +290,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentListResponse.php
+++ b/src/Model/DocumentListResponse.php
@@ -233,6 +233,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +246,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +260,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +277,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +290,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -314,5 +319,3 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentListResponseResults.php
+++ b/src/Model/DocumentListResponseResults.php
@@ -413,7 +413,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -426,7 +426,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -440,7 +440,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -457,7 +457,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -470,7 +470,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentListResponseResults.php
+++ b/src/Model/DocumentListResponseResults.php
@@ -413,6 +413,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -425,6 +426,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -438,6 +440,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -454,6 +457,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -466,6 +470,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -494,5 +499,3 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentSendRequest.php
+++ b/src/Model/DocumentSendRequest.php
@@ -323,7 +323,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -336,7 +336,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -350,7 +350,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -367,7 +367,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -380,7 +380,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentSendRequest.php
+++ b/src/Model/DocumentSendRequest.php
@@ -323,6 +323,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -335,6 +336,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -348,6 +350,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -364,6 +367,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -376,6 +380,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -404,5 +409,3 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentSendResponse.php
+++ b/src/Model/DocumentSendResponse.php
@@ -473,7 +473,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -486,7 +486,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -500,7 +500,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -517,7 +517,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -530,7 +530,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentSendResponse.php
+++ b/src/Model/DocumentSendResponse.php
@@ -473,6 +473,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -485,6 +486,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -498,6 +500,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -514,6 +517,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -526,6 +530,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -554,5 +559,3 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentStatusChangeRequest.php
+++ b/src/Model/DocumentStatusChangeRequest.php
@@ -296,7 +296,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -309,7 +309,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -323,7 +323,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -340,7 +340,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -353,7 +353,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentStatusChangeRequest.php
+++ b/src/Model/DocumentStatusChangeRequest.php
@@ -296,6 +296,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -308,6 +309,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -321,6 +323,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -337,6 +340,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -349,6 +353,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -377,5 +382,3 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentStatusResponse.php
+++ b/src/Model/DocumentStatusResponse.php
@@ -473,7 +473,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -486,7 +486,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -500,7 +500,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -517,7 +517,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -530,7 +530,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentStatusResponse.php
+++ b/src/Model/DocumentStatusResponse.php
@@ -473,6 +473,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -485,6 +486,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -498,6 +500,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -514,6 +517,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -526,6 +530,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -554,5 +559,3 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentTransferAllOwnershipRequest.php
+++ b/src/Model/DocumentTransferAllOwnershipRequest.php
@@ -263,7 +263,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -276,7 +276,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -290,7 +290,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -307,7 +307,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -320,7 +320,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentTransferAllOwnershipRequest.php
+++ b/src/Model/DocumentTransferAllOwnershipRequest.php
@@ -263,6 +263,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -275,6 +276,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -288,6 +290,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -304,6 +307,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -316,6 +320,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -344,5 +349,3 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentTransferOwnershipRequest.php
+++ b/src/Model/DocumentTransferOwnershipRequest.php
@@ -233,6 +233,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +246,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +260,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +277,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +290,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -314,5 +319,3 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentTransferOwnershipRequest.php
+++ b/src/Model/DocumentTransferOwnershipRequest.php
@@ -233,7 +233,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -246,7 +246,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -260,7 +260,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -277,7 +277,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -290,7 +290,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentUpdateRequest.php
+++ b/src/Model/DocumentUpdateRequest.php
@@ -353,7 +353,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -366,7 +366,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -380,7 +380,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -397,7 +397,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -410,7 +410,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentUpdateRequest.php
+++ b/src/Model/DocumentUpdateRequest.php
@@ -353,6 +353,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -365,6 +366,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -378,6 +380,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -394,6 +397,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -406,6 +410,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -434,5 +439,3 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentUpdateRequestRecipients.php
+++ b/src/Model/DocumentUpdateRequestRecipients.php
@@ -323,6 +323,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -335,6 +336,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -348,6 +350,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -364,6 +367,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -376,6 +380,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -404,5 +409,3 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentUpdateRequestRecipients.php
+++ b/src/Model/DocumentUpdateRequestRecipients.php
@@ -323,7 +323,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -336,7 +336,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -350,7 +350,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -367,7 +367,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -380,7 +380,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentsFolderCreateRequest.php
+++ b/src/Model/DocumentsFolderCreateRequest.php
@@ -266,7 +266,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -279,7 +279,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -293,7 +293,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -310,7 +310,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -323,7 +323,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentsFolderCreateRequest.php
+++ b/src/Model/DocumentsFolderCreateRequest.php
@@ -266,6 +266,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -278,6 +279,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -291,6 +293,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -307,6 +310,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -319,6 +323,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -347,5 +352,3 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentsFolderCreateResponse.php
+++ b/src/Model/DocumentsFolderCreateResponse.php
@@ -293,7 +293,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -306,7 +306,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -320,7 +320,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -337,7 +337,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -350,7 +350,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentsFolderCreateResponse.php
+++ b/src/Model/DocumentsFolderCreateResponse.php
@@ -293,6 +293,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -305,6 +306,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -318,6 +320,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -334,6 +337,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -346,6 +350,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -374,5 +379,3 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentsFolderListResponse.php
+++ b/src/Model/DocumentsFolderListResponse.php
@@ -233,6 +233,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +246,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +260,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +277,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +290,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -314,5 +319,3 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentsFolderListResponse.php
+++ b/src/Model/DocumentsFolderListResponse.php
@@ -233,7 +233,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -246,7 +246,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -260,7 +260,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -277,7 +277,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -290,7 +290,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentsFolderListResponseResults.php
+++ b/src/Model/DocumentsFolderListResponseResults.php
@@ -353,7 +353,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -366,7 +366,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -380,7 +380,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -397,7 +397,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -410,7 +410,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentsFolderListResponseResults.php
+++ b/src/Model/DocumentsFolderListResponseResults.php
@@ -353,6 +353,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -365,6 +366,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -378,6 +380,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -394,6 +397,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -406,6 +410,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -434,5 +439,3 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentsFolderRenameRequest.php
+++ b/src/Model/DocumentsFolderRenameRequest.php
@@ -236,7 +236,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -249,7 +249,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -263,7 +263,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -280,7 +280,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -293,7 +293,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentsFolderRenameRequest.php
+++ b/src/Model/DocumentsFolderRenameRequest.php
@@ -236,6 +236,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -248,6 +249,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -261,6 +263,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -277,6 +280,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -289,6 +293,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -317,5 +322,3 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/DocumentsFolderRenameResponse.php
+++ b/src/Model/DocumentsFolderRenameResponse.php
@@ -293,7 +293,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -306,7 +306,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -320,7 +320,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -337,7 +337,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -350,7 +350,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/DocumentsFolderRenameResponse.php
+++ b/src/Model/DocumentsFolderRenameResponse.php
@@ -293,6 +293,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -305,6 +306,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -318,6 +320,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -334,6 +337,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -346,6 +350,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -374,5 +379,3 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/FormListResponse.php
+++ b/src/Model/FormListResponse.php
@@ -263,6 +263,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -275,6 +276,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -288,6 +290,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -304,6 +307,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -316,6 +320,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -344,5 +349,3 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/FormListResponse.php
+++ b/src/Model/FormListResponse.php
@@ -263,7 +263,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -276,7 +276,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -290,7 +290,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -307,7 +307,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -320,7 +320,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/FormListResponseResults.php
+++ b/src/Model/FormListResponseResults.php
@@ -353,7 +353,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -366,7 +366,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -380,7 +380,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -397,7 +397,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -410,7 +410,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/FormListResponseResults.php
+++ b/src/Model/FormListResponseResults.php
@@ -353,6 +353,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -365,6 +366,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -378,6 +380,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -394,6 +397,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -406,6 +410,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -434,5 +439,3 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/LinkedObjectCreateRequest.php
+++ b/src/Model/LinkedObjectCreateRequest.php
@@ -302,6 +302,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -314,6 +315,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -327,6 +329,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -343,6 +346,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -355,6 +359,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -383,5 +388,3 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/LinkedObjectCreateRequest.php
+++ b/src/Model/LinkedObjectCreateRequest.php
@@ -302,7 +302,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -315,7 +315,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -329,7 +329,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -346,7 +346,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -359,7 +359,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/LinkedObjectCreateResponse.php
+++ b/src/Model/LinkedObjectCreateResponse.php
@@ -323,7 +323,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -336,7 +336,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -350,7 +350,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -367,7 +367,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -380,7 +380,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/LinkedObjectCreateResponse.php
+++ b/src/Model/LinkedObjectCreateResponse.php
@@ -323,6 +323,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -335,6 +336,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -348,6 +350,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -364,6 +367,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -376,6 +380,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -404,5 +409,3 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/LinkedObjectListResponse.php
+++ b/src/Model/LinkedObjectListResponse.php
@@ -233,6 +233,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +246,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +260,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +277,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +290,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -314,5 +319,3 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/LinkedObjectListResponse.php
+++ b/src/Model/LinkedObjectListResponse.php
@@ -233,7 +233,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -246,7 +246,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -260,7 +260,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -277,7 +277,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -290,7 +290,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/MemberDetailsResponse.php
+++ b/src/Model/MemberDetailsResponse.php
@@ -593,7 +593,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -606,7 +606,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -620,7 +620,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -637,7 +637,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -650,7 +650,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/MemberDetailsResponse.php
+++ b/src/Model/MemberDetailsResponse.php
@@ -593,6 +593,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -605,6 +606,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -618,6 +620,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -634,6 +637,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -646,6 +650,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -674,5 +679,3 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/MemberListResponse.php
+++ b/src/Model/MemberListResponse.php
@@ -233,7 +233,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -246,7 +246,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -260,7 +260,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -277,7 +277,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -290,7 +290,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/MemberListResponse.php
+++ b/src/Model/MemberListResponse.php
@@ -233,6 +233,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +246,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +260,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +277,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +290,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -314,5 +319,3 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/OAuth2AccessTokenResponse.php
+++ b/src/Model/OAuth2AccessTokenResponse.php
@@ -353,6 +353,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -365,6 +366,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -378,6 +380,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -394,6 +397,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -406,6 +410,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -434,5 +439,3 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/OAuth2AccessTokenResponse.php
+++ b/src/Model/OAuth2AccessTokenResponse.php
@@ -353,7 +353,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -366,7 +366,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -380,7 +380,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -397,7 +397,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -410,7 +410,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/PricingTableRequest.php
+++ b/src/Model/PricingTableRequest.php
@@ -326,6 +326,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -338,6 +339,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -351,6 +353,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -367,6 +370,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -379,6 +383,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -407,5 +412,3 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/PricingTableRequest.php
+++ b/src/Model/PricingTableRequest.php
@@ -326,7 +326,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -339,7 +339,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -353,7 +353,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -370,7 +370,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -383,7 +383,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/PricingTableRequestRowOptions.php
+++ b/src/Model/PricingTableRequestRowOptions.php
@@ -293,6 +293,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -305,6 +306,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -318,6 +320,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -334,6 +337,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -346,6 +350,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -374,5 +379,3 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/PricingTableRequestRowOptions.php
+++ b/src/Model/PricingTableRequestRowOptions.php
@@ -293,7 +293,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -306,7 +306,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -320,7 +320,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -337,7 +337,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -350,7 +350,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/PricingTableRequestRows.php
+++ b/src/Model/PricingTableRequestRows.php
@@ -293,6 +293,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -305,6 +306,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -318,6 +320,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -334,6 +337,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -346,6 +350,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -374,5 +379,3 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/PricingTableRequestRows.php
+++ b/src/Model/PricingTableRequestRows.php
@@ -293,7 +293,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -306,7 +306,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -320,7 +320,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -337,7 +337,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -350,7 +350,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/PricingTableRequestSections.php
+++ b/src/Model/PricingTableRequestSections.php
@@ -326,6 +326,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -338,6 +339,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -351,6 +353,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -367,6 +370,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -379,6 +383,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -407,5 +412,3 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/PricingTableRequestSections.php
+++ b/src/Model/PricingTableRequestSections.php
@@ -326,7 +326,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -339,7 +339,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -353,7 +353,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -370,7 +370,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -383,7 +383,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/PricingTablesResponse.php
+++ b/src/Model/PricingTablesResponse.php
@@ -263,6 +263,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -275,6 +276,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -288,6 +290,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -304,6 +307,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -316,6 +320,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -344,5 +349,3 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/PricingTablesResponse.php
+++ b/src/Model/PricingTablesResponse.php
@@ -263,7 +263,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -276,7 +276,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -290,7 +290,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -307,7 +307,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -320,7 +320,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/PricingTablesResponseDiscount.php
+++ b/src/Model/PricingTablesResponseDiscount.php
@@ -263,7 +263,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -276,7 +276,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -290,7 +290,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -307,7 +307,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -320,7 +320,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/PricingTablesResponseDiscount.php
+++ b/src/Model/PricingTablesResponseDiscount.php
@@ -263,6 +263,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -275,6 +276,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -288,6 +290,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -304,6 +307,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -316,6 +320,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -344,5 +349,3 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/PricingTablesResponseItems.php
+++ b/src/Model/PricingTablesResponseItems.php
@@ -773,6 +773,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -785,6 +786,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -798,6 +800,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -814,6 +817,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -826,6 +830,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -854,5 +859,3 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/PricingTablesResponseItems.php
+++ b/src/Model/PricingTablesResponseItems.php
@@ -773,7 +773,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -786,7 +786,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -800,7 +800,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -817,7 +817,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -830,7 +830,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/PricingTablesResponseOptions.php
+++ b/src/Model/PricingTablesResponseOptions.php
@@ -323,7 +323,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -336,7 +336,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -350,7 +350,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -367,7 +367,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -380,7 +380,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/PricingTablesResponseOptions.php
+++ b/src/Model/PricingTablesResponseOptions.php
@@ -323,6 +323,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -335,6 +336,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -348,6 +350,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -364,6 +367,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -376,6 +380,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -404,5 +409,3 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/PricingTablesResponseSummary.php
+++ b/src/Model/PricingTablesResponseSummary.php
@@ -323,7 +323,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -336,7 +336,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -350,7 +350,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -367,7 +367,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -380,7 +380,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/PricingTablesResponseSummary.php
+++ b/src/Model/PricingTablesResponseSummary.php
@@ -323,6 +323,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -335,6 +336,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -348,6 +350,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -364,6 +367,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -376,6 +380,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -404,5 +409,3 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/PricingTablesResponseTables.php
+++ b/src/Model/PricingTablesResponseTables.php
@@ -413,6 +413,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -425,6 +426,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -438,6 +440,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -454,6 +457,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -466,6 +470,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -494,5 +499,3 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/PricingTablesResponseTables.php
+++ b/src/Model/PricingTablesResponseTables.php
@@ -413,7 +413,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -426,7 +426,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -440,7 +440,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -457,7 +457,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -470,7 +470,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/TemplateDetailsResponse.php
+++ b/src/Model/TemplateDetailsResponse.php
@@ -623,7 +623,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -636,7 +636,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -650,7 +650,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -667,7 +667,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -680,7 +680,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/TemplateDetailsResponse.php
+++ b/src/Model/TemplateDetailsResponse.php
@@ -623,6 +623,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -635,6 +636,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -648,6 +650,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -664,6 +667,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -676,6 +680,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -704,5 +709,3 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/TemplateDetailsResponseContentPlaceholders.php
+++ b/src/Model/TemplateDetailsResponseContentPlaceholders.php
@@ -293,7 +293,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -306,7 +306,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -320,7 +320,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -337,7 +337,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -350,7 +350,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/TemplateDetailsResponseContentPlaceholders.php
+++ b/src/Model/TemplateDetailsResponseContentPlaceholders.php
@@ -293,6 +293,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -305,6 +306,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -318,6 +320,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -334,6 +337,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -346,6 +350,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -374,5 +379,3 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/TemplateDetailsResponseImages.php
+++ b/src/Model/TemplateDetailsResponseImages.php
@@ -293,7 +293,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -306,7 +306,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -320,7 +320,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -337,7 +337,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -350,7 +350,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/TemplateDetailsResponseImages.php
+++ b/src/Model/TemplateDetailsResponseImages.php
@@ -293,6 +293,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -305,6 +306,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -318,6 +320,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -334,6 +337,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -346,6 +350,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -374,5 +379,3 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/TemplateDetailsResponsePreassignedPerson.php
+++ b/src/Model/TemplateDetailsResponsePreassignedPerson.php
@@ -263,7 +263,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -276,7 +276,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -290,7 +290,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -307,7 +307,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -320,7 +320,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/TemplateDetailsResponsePreassignedPerson.php
+++ b/src/Model/TemplateDetailsResponsePreassignedPerson.php
@@ -263,6 +263,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -275,6 +276,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -288,6 +290,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -304,6 +307,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -316,6 +320,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -344,5 +349,3 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/TemplateDetailsResponseRoles.php
+++ b/src/Model/TemplateDetailsResponseRoles.php
@@ -323,7 +323,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -336,7 +336,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -350,7 +350,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -367,7 +367,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -380,7 +380,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/TemplateDetailsResponseRoles.php
+++ b/src/Model/TemplateDetailsResponseRoles.php
@@ -323,6 +323,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -335,6 +336,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -348,6 +350,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -364,6 +367,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -376,6 +380,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -404,5 +409,3 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/TemplateDetailsResponseTokens.php
+++ b/src/Model/TemplateDetailsResponseTokens.php
@@ -263,7 +263,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -276,7 +276,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -290,7 +290,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -307,7 +307,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -320,7 +320,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/TemplateDetailsResponseTokens.php
+++ b/src/Model/TemplateDetailsResponseTokens.php
@@ -263,6 +263,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -275,6 +276,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -288,6 +290,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -304,6 +307,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -316,6 +320,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -344,5 +349,3 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/TemplateListResponse.php
+++ b/src/Model/TemplateListResponse.php
@@ -233,6 +233,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +246,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +260,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +277,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +290,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -314,5 +319,3 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/TemplateListResponse.php
+++ b/src/Model/TemplateListResponse.php
@@ -233,7 +233,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -246,7 +246,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -260,7 +260,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -277,7 +277,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -290,7 +290,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/TemplateListResponseResults.php
+++ b/src/Model/TemplateListResponseResults.php
@@ -353,6 +353,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -365,6 +366,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -378,6 +380,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -394,6 +397,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -406,6 +410,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -434,5 +439,3 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/TemplateListResponseResults.php
+++ b/src/Model/TemplateListResponseResults.php
@@ -353,7 +353,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -366,7 +366,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -380,7 +380,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -397,7 +397,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -410,7 +410,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/TemplatesFolderCreateRequest.php
+++ b/src/Model/TemplatesFolderCreateRequest.php
@@ -266,7 +266,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -279,7 +279,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -293,7 +293,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -310,7 +310,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -323,7 +323,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/TemplatesFolderCreateRequest.php
+++ b/src/Model/TemplatesFolderCreateRequest.php
@@ -266,6 +266,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -278,6 +279,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -291,6 +293,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -307,6 +310,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -319,6 +323,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -347,5 +352,3 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/TemplatesFolderCreateResponse.php
+++ b/src/Model/TemplatesFolderCreateResponse.php
@@ -293,6 +293,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -305,6 +306,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -318,6 +320,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -334,6 +337,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -346,6 +350,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -374,5 +379,3 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/TemplatesFolderCreateResponse.php
+++ b/src/Model/TemplatesFolderCreateResponse.php
@@ -293,7 +293,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -306,7 +306,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -320,7 +320,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -337,7 +337,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -350,7 +350,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/TemplatesFolderListResponse.php
+++ b/src/Model/TemplatesFolderListResponse.php
@@ -233,7 +233,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -246,7 +246,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -260,7 +260,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -277,7 +277,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -290,7 +290,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/TemplatesFolderListResponse.php
+++ b/src/Model/TemplatesFolderListResponse.php
@@ -233,6 +233,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +246,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +260,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +277,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +290,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -314,5 +319,3 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/TemplatesFolderListResponseResults.php
+++ b/src/Model/TemplatesFolderListResponseResults.php
@@ -353,6 +353,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -365,6 +366,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -378,6 +380,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -394,6 +397,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -406,6 +410,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -434,5 +439,3 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/TemplatesFolderListResponseResults.php
+++ b/src/Model/TemplatesFolderListResponseResults.php
@@ -353,7 +353,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -366,7 +366,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -380,7 +380,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -397,7 +397,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -410,7 +410,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/TemplatesFolderRenameRequest.php
+++ b/src/Model/TemplatesFolderRenameRequest.php
@@ -236,6 +236,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -248,6 +249,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -261,6 +263,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -277,6 +280,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -289,6 +293,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -317,5 +322,3 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/TemplatesFolderRenameRequest.php
+++ b/src/Model/TemplatesFolderRenameRequest.php
@@ -236,7 +236,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -249,7 +249,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -263,7 +263,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -280,7 +280,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -293,7 +293,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/TemplatesFolderRenameResponse.php
+++ b/src/Model/TemplatesFolderRenameResponse.php
@@ -293,7 +293,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -306,7 +306,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -320,7 +320,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -337,7 +337,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -350,7 +350,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/TemplatesFolderRenameResponse.php
+++ b/src/Model/TemplatesFolderRenameResponse.php
@@ -293,6 +293,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -305,6 +306,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -318,6 +320,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -334,6 +337,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -346,6 +350,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -374,5 +379,3 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/WebhookEventDetailsResponse.php
+++ b/src/Model/WebhookEventDetailsResponse.php
@@ -563,6 +563,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -575,6 +576,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -588,6 +590,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -604,6 +607,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -616,6 +620,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -644,5 +649,3 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/WebhookEventDetailsResponse.php
+++ b/src/Model/WebhookEventDetailsResponse.php
@@ -563,7 +563,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -576,7 +576,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -590,7 +590,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -607,7 +607,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -620,7 +620,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/WebhookEventItemResponse.php
+++ b/src/Model/WebhookEventItemResponse.php
@@ -383,7 +383,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -396,7 +396,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -410,7 +410,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -427,7 +427,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -440,7 +440,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/WebhookEventItemResponse.php
+++ b/src/Model/WebhookEventItemResponse.php
@@ -383,6 +383,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -395,6 +396,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -408,6 +410,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -424,6 +427,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -436,6 +440,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -464,5 +469,3 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/WebhookEventPageResponse.php
+++ b/src/Model/WebhookEventPageResponse.php
@@ -233,7 +233,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -246,7 +246,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -260,7 +260,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -277,7 +277,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -290,7 +290,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/WebhookEventPageResponse.php
+++ b/src/Model/WebhookEventPageResponse.php
@@ -233,6 +233,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +246,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +260,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +277,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +290,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -314,5 +319,3 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/WebhookSubscriptionCreateRequest.php
+++ b/src/Model/WebhookSubscriptionCreateRequest.php
@@ -332,7 +332,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -345,7 +345,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -359,7 +359,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -376,7 +376,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -389,7 +389,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/WebhookSubscriptionCreateRequest.php
+++ b/src/Model/WebhookSubscriptionCreateRequest.php
@@ -332,6 +332,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -344,6 +345,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -357,6 +359,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -373,6 +376,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -385,6 +389,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -413,5 +418,3 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/WebhookSubscriptionItemResponse.php
+++ b/src/Model/WebhookSubscriptionItemResponse.php
@@ -473,7 +473,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -486,7 +486,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -500,7 +500,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -517,7 +517,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -530,7 +530,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/WebhookSubscriptionItemResponse.php
+++ b/src/Model/WebhookSubscriptionItemResponse.php
@@ -473,6 +473,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -485,6 +486,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -498,6 +500,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -514,6 +517,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -526,6 +530,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -554,5 +559,3 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/WebhookSubscriptionListResponse.php
+++ b/src/Model/WebhookSubscriptionListResponse.php
@@ -233,7 +233,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -246,7 +246,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -260,7 +260,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -277,7 +277,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -290,7 +290,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/WebhookSubscriptionListResponse.php
+++ b/src/Model/WebhookSubscriptionListResponse.php
@@ -233,6 +233,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +246,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +260,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +277,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +290,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -314,5 +319,3 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/WebhookSubscriptionPatchRequest.php
+++ b/src/Model/WebhookSubscriptionPatchRequest.php
@@ -353,7 +353,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -366,7 +366,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -380,7 +380,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -397,7 +397,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -410,7 +410,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/src/Model/WebhookSubscriptionPatchRequest.php
+++ b/src/Model/WebhookSubscriptionPatchRequest.php
@@ -353,6 +353,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -365,6 +366,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -378,6 +380,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -394,6 +397,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -406,6 +410,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -434,5 +439,3 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/WebhookSubscriptionSharedKeyResponse.php
+++ b/src/Model/WebhookSubscriptionSharedKeyResponse.php
@@ -233,6 +233,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +246,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      *
      * @return mixed|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +260,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +277,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +290,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -314,5 +319,3 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/src/Model/WebhookSubscriptionSharedKeyResponse.php
+++ b/src/Model/WebhookSubscriptionSharedKeyResponse.php
@@ -233,7 +233,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      *
      * @return boolean
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -246,7 +246,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      *
      * @return mixed|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -260,7 +260,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -277,7 +277,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -290,7 +290,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);


### PR DESCRIPTION
This Pull Request fixes some deprecation warnings when this package is used in PHP 8.1, while keeping it compatible with the PHP version defined in **composer.json** as the included [attributes](https://www.php.net/manual/en/language.attributes.overview.php) are considered [comments](https://www.php.net/manual/en/language.basic-syntax.comments.php) for `^7.3` and will correctly suppress the warning in `^8.0`.

Example of warning being fixed:
```html
<b>Deprecated</b>: Return type of PandaDoc\Client\Model\DocumentCreateLinkResponse::jsonSerialize() should either be
compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to
temporarily suppress the notice in <b>/var/www/vendor/pandadoc/php-client/src/Model/DocumentCreateLinkResponse.php</b>
on line <b>319</b>
```