### PR TITLE
v5.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ or add the following to `composer.json`:
 ```json
 {
   "require": {
-    "pandadoc/php-client": "5.5.0"
+    "pandadoc/php-client": "5.5.1"
   }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "pandadoc/php-client",
-    "version": "5.5.0",
+    "version": "5.5.1",
     "description": "The Official PandaDoc PHP client SDK",
     "keywords": [
         "openapi",

--- a/src/ApiException.php
+++ b/src/ApiException.php
@@ -79,6 +79,7 @@ class ApiException extends Exception
      *
      * @return string[]|null HTTP response header
      */
+    #[\ReturnTypeWillChange]
     public function getResponseHeaders()
     {
         return $this->responseHeaders;
@@ -89,6 +90,7 @@ class ApiException extends Exception
      *
      * @return \stdClass|string|null HTTP body of the server response either as \stdClass or string
      */
+    #[\ReturnTypeWillChange]
     public function getResponseBody()
     {
         return $this->responseBody;
@@ -111,6 +113,7 @@ class ApiException extends Exception
      *
      * @return mixed the deserialized response object
      */
+    #[\ReturnTypeWillChange]
     public function getResponseObject()
     {
         return $this->responseObject;

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -88,7 +88,7 @@ class Configuration
      *
      * @var string
      */
-    protected $userAgent = 'pandadoc_php_client/5.5.0';
+    protected $userAgent = 'pandadoc_php_client/5.5.1';
 
     /**
      * Debug switch (default set to false)
@@ -127,6 +127,7 @@ class Configuration
      *
      * @return $this
      */
+    #[\ReturnTypeWillChange]
     public function setApiKey($apiKeyIdentifier, $key)
     {
         $this->apiKeys[$apiKeyIdentifier] = $key;
@@ -140,6 +141,7 @@ class Configuration
      *
      * @return null|string API key or token
      */
+    #[\ReturnTypeWillChange]
     public function getApiKey($apiKeyIdentifier)
     {
         return isset($this->apiKeys[$apiKeyIdentifier]) ? $this->apiKeys[$apiKeyIdentifier] : null;
@@ -153,6 +155,7 @@ class Configuration
      *
      * @return $this
      */
+    #[\ReturnTypeWillChange]
     public function setApiKeyPrefix($apiKeyIdentifier, $prefix)
     {
         $this->apiKeyPrefixes[$apiKeyIdentifier] = $prefix;
@@ -166,6 +169,7 @@ class Configuration
      *
      * @return null|string
      */
+    #[\ReturnTypeWillChange]
     public function getApiKeyPrefix($apiKeyIdentifier)
     {
         return isset($this->apiKeyPrefixes[$apiKeyIdentifier]) ? $this->apiKeyPrefixes[$apiKeyIdentifier] : null;
@@ -178,6 +182,7 @@ class Configuration
      *
      * @return $this
      */
+    #[\ReturnTypeWillChange]
     public function setAccessToken($accessToken)
     {
         $this->accessToken = $accessToken;
@@ -189,6 +194,7 @@ class Configuration
      *
      * @return string Access token for OAuth
      */
+    #[\ReturnTypeWillChange]
     public function getAccessToken()
     {
         return $this->accessToken;
@@ -201,6 +207,7 @@ class Configuration
      *
      * @return $this
      */
+    #[\ReturnTypeWillChange]
     public function setUsername($username)
     {
         $this->username = $username;
@@ -212,6 +219,7 @@ class Configuration
      *
      * @return string Username for HTTP basic authentication
      */
+    #[\ReturnTypeWillChange]
     public function getUsername()
     {
         return $this->username;
@@ -224,6 +232,7 @@ class Configuration
      *
      * @return $this
      */
+    #[\ReturnTypeWillChange]
     public function setPassword($password)
     {
         $this->password = $password;
@@ -235,6 +244,7 @@ class Configuration
      *
      * @return string Password for HTTP basic authentication
      */
+    #[\ReturnTypeWillChange]
     public function getPassword()
     {
         return $this->password;
@@ -247,6 +257,7 @@ class Configuration
      *
      * @return $this
      */
+    #[\ReturnTypeWillChange]
     public function setHost($host)
     {
         $this->host = $host;
@@ -258,6 +269,7 @@ class Configuration
      *
      * @return string Host
      */
+    #[\ReturnTypeWillChange]
     public function getHost()
     {
         return $this->host;
@@ -271,6 +283,7 @@ class Configuration
      * @throws \InvalidArgumentException
      * @return $this
      */
+    #[\ReturnTypeWillChange]
     public function setUserAgent($userAgent)
     {
         if (!is_string($userAgent)) {
@@ -286,6 +299,7 @@ class Configuration
      *
      * @return string user agent
      */
+    #[\ReturnTypeWillChange]
     public function getUserAgent()
     {
         return $this->userAgent;
@@ -298,6 +312,7 @@ class Configuration
      *
      * @return $this
      */
+    #[\ReturnTypeWillChange]
     public function setDebug($debug)
     {
         $this->debug = $debug;
@@ -309,6 +324,7 @@ class Configuration
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function getDebug()
     {
         return $this->debug;
@@ -321,6 +337,7 @@ class Configuration
      *
      * @return $this
      */
+    #[\ReturnTypeWillChange]
     public function setDebugFile($debugFile)
     {
         $this->debugFile = $debugFile;
@@ -332,6 +349,7 @@ class Configuration
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getDebugFile()
     {
         return $this->debugFile;
@@ -344,6 +362,7 @@ class Configuration
      *
      * @return $this
      */
+    #[\ReturnTypeWillChange]
     public function setTempFolderPath($tempFolderPath)
     {
         $this->tempFolderPath = $tempFolderPath;
@@ -355,6 +374,7 @@ class Configuration
      *
      * @return string Temp folder path
      */
+    #[\ReturnTypeWillChange]
     public function getTempFolderPath()
     {
         return $this->tempFolderPath;
@@ -365,6 +385,7 @@ class Configuration
      *
      * @return Configuration
      */
+    #[\ReturnTypeWillChange]
     public static function getDefaultConfiguration()
     {
         if (self::$defaultConfiguration === null) {
@@ -381,6 +402,7 @@ class Configuration
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public static function setDefaultConfiguration(Configuration $config)
     {
         self::$defaultConfiguration = $config;
@@ -391,13 +413,14 @@ class Configuration
      *
      * @return string The report for debugging
      */
+    #[\ReturnTypeWillChange]
     public static function toDebugReport()
     {
         $report  = 'PHP SDK (PandaDoc\Client) Debug Report:' . PHP_EOL;
         $report .= '    OS: ' . php_uname() . PHP_EOL;
         $report .= '    PHP Version: ' . PHP_VERSION . PHP_EOL;
         $report .= '    The version of the OpenAPI document: 5.5.0' . PHP_EOL;
-        $report .= '    SDK Package Version: 5.5.0' . PHP_EOL;
+        $report .= '    SDK Package Version: 5.5.1' . PHP_EOL;
         $report .= '    Temp Folder Path: ' . self::getDefaultConfiguration()->getTempFolderPath() . PHP_EOL;
 
         return $report;
@@ -410,6 +433,7 @@ class Configuration
      *
      * @return null|string API key with the prefix
      */
+    #[\ReturnTypeWillChange]
     public function getApiKeyWithPrefix($apiKeyIdentifier)
     {
         $prefix = $this->getApiKeyPrefix($apiKeyIdentifier);
@@ -433,6 +457,7 @@ class Configuration
      *
      * @return array an array of host settings
      */
+    #[\ReturnTypeWillChange]
     public function getHostSettings()
     {
         return [
@@ -450,6 +475,7 @@ class Configuration
      * @param array|null $variables hash of variable and the corresponding value (optional)
      * @return string URL based on host settings
      */
+    #[\ReturnTypeWillChange]
     public function getHostFromSettings($index, $variables = null)
     {
         if (null === $variables) {

--- a/src/HeaderSelector.php
+++ b/src/HeaderSelector.php
@@ -43,6 +43,7 @@ class HeaderSelector
      * @param string[] $contentTypes
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function selectHeaders($accept, $contentTypes)
     {
         $headers = [];
@@ -60,6 +61,7 @@ class HeaderSelector
      * @param string[] $accept
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function selectHeadersForMultipart($accept)
     {
         $headers = $this->selectHeaders($accept, []);
@@ -75,6 +77,7 @@ class HeaderSelector
      *
      * @return null|string Accept (e.g. application/json)
      */
+    #[\ReturnTypeWillChange]
     private function selectAcceptHeader($accept)
     {
         if (count($accept) === 0 || (count($accept) === 1 && $accept[0] === '')) {
@@ -93,6 +96,7 @@ class HeaderSelector
      *
      * @return string Content-Type (e.g. application/json)
      */
+    #[\ReturnTypeWillChange]
     private function selectContentTypeHeader($contentType)
     {
         if (count($contentType) === 0 || (count($contentType) === 1 && $contentType[0] === '')) {

--- a/src/Model/APILogDetailsResponse.php
+++ b/src/Model/APILogDetailsResponse.php
@@ -106,6 +106,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -116,6 +117,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -200,6 +202,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -210,6 +213,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -220,6 +224,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -230,6 +235,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -274,6 +280,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -287,6 +294,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -298,6 +306,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -310,6 +319,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -322,6 +332,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getUrl()
     {
         return $this->container['url'];
@@ -334,6 +345,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUrl($url)
     {
         $this->container['url'] = $url;
@@ -346,6 +358,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getMethod()
     {
         return $this->container['method'];
@@ -358,6 +371,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setMethod($method)
     {
         $this->container['method'] = $method;
@@ -370,6 +384,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return int|null
      */
+    #[\ReturnTypeWillChange]
     public function getStatus()
     {
         return $this->container['status'];
@@ -382,6 +397,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setStatus($status)
     {
         $this->container['status'] = $status;
@@ -394,6 +410,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getRequestTime()
     {
         return $this->container['requestTime'];
@@ -406,6 +423,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setRequestTime($requestTime)
     {
         $this->container['requestTime'] = $requestTime;
@@ -418,6 +436,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getResponseTime()
     {
         return $this->container['responseTime'];
@@ -430,6 +449,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setResponseTime($responseTime)
     {
         $this->container['responseTime'] = $responseTime;
@@ -442,6 +462,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getResponseBody()
     {
         return $this->container['responseBody'];
@@ -454,6 +475,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setResponseBody($responseBody)
     {
         $this->container['responseBody'] = $responseBody;
@@ -466,6 +488,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getQueryParamsString()
     {
         return $this->container['queryParamsString'];
@@ -478,6 +501,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setQueryParamsString($queryParamsString)
     {
         $this->container['queryParamsString'] = $queryParamsString;
@@ -490,6 +514,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getQueryParamsObject()
     {
         return $this->container['queryParamsObject'];
@@ -502,6 +527,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setQueryParamsObject($queryParamsObject)
     {
         $this->container['queryParamsObject'] = $queryParamsObject;
@@ -514,6 +540,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getRequestBody()
     {
         return $this->container['requestBody'];
@@ -526,6 +553,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setRequestBody($requestBody)
     {
         $this->container['requestBody'] = $requestBody;
@@ -538,6 +566,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getTokenType()
     {
         return $this->container['tokenType'];
@@ -550,6 +579,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTokenType($tokenType)
     {
         $this->container['tokenType'] = $tokenType;
@@ -562,6 +592,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getApplication()
     {
         return $this->container['application'];
@@ -574,6 +605,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setApplication($application)
     {
         $this->container['application'] = $application;
@@ -586,6 +618,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getKey()
     {
         return $this->container['key'];
@@ -598,6 +631,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setKey($key)
     {
         $this->container['key'] = $key;
@@ -610,6 +644,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getRequestId()
     {
         return $this->container['requestId'];
@@ -622,6 +657,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setRequestId($requestId)
     {
         $this->container['requestId'] = $requestId;
@@ -634,6 +670,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getUserEmail()
     {
         return $this->container['userEmail'];
@@ -646,6 +683,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUserEmail($userEmail)
     {
         $this->container['userEmail'] = $userEmail;
@@ -658,6 +696,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getUserId()
     {
         return $this->container['userId'];
@@ -670,6 +709,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUserId($userId)
     {
         $this->container['userId'] = $userId;
@@ -683,6 +723,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -695,6 +736,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -708,6 +750,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -724,6 +767,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -736,6 +780,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -746,6 +791,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -759,6 +805,7 @@ class APILogDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/APILogListResponse.php
+++ b/src/Model/APILogListResponse.php
@@ -76,6 +76,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -86,6 +87,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -125,6 +127,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -135,6 +138,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -145,6 +149,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -155,6 +160,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -184,6 +190,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -197,6 +204,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -208,6 +216,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return \PandaDoc\Client\Model\APILogListResponseResults[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getResults()
     {
         return $this->container['results'];
@@ -220,6 +229,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setResults($results)
     {
         $this->container['results'] = $results;
@@ -233,6 +243,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +256,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +270,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +287,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +300,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -296,6 +311,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -309,6 +325,7 @@ class APILogListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/APILogListResponseResults.php
+++ b/src/Model/APILogListResponseResults.php
@@ -84,6 +84,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -94,6 +95,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -145,6 +147,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -155,6 +158,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -165,6 +169,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -175,6 +180,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -208,6 +214,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -221,6 +228,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -232,6 +240,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -244,6 +253,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -256,6 +266,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getUrl()
     {
         return $this->container['url'];
@@ -268,6 +279,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUrl($url)
     {
         $this->container['url'] = $url;
@@ -280,6 +292,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return int|null
      */
+    #[\ReturnTypeWillChange]
     public function getStatus()
     {
         return $this->container['status'];
@@ -292,6 +305,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setStatus($status)
     {
         $this->container['status'] = $status;
@@ -304,6 +318,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getRequestTime()
     {
         return $this->container['requestTime'];
@@ -316,6 +331,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setRequestTime($requestTime)
     {
         $this->container['requestTime'] = $requestTime;
@@ -328,6 +344,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getResponseTime()
     {
         return $this->container['responseTime'];
@@ -340,6 +357,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setResponseTime($responseTime)
     {
         $this->container['responseTime'] = $responseTime;
@@ -353,6 +371,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -365,6 +384,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -378,6 +398,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -394,6 +415,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -406,6 +428,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -416,6 +439,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -429,6 +453,7 @@ class APILogListResponseResults implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/ContactCreateRequest.php
+++ b/src/Model/ContactCreateRequest.php
@@ -94,6 +94,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -104,6 +105,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -170,6 +172,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -180,6 +183,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -190,6 +194,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -200,6 +205,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -238,6 +244,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -254,6 +261,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -265,6 +273,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getEmail()
     {
         return $this->container['email'];
@@ -277,6 +286,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setEmail($email)
     {
         $this->container['email'] = $email;
@@ -289,6 +299,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getFirstName()
     {
         return $this->container['firstName'];
@@ -301,6 +312,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setFirstName($firstName)
     {
         $this->container['firstName'] = $firstName;
@@ -313,6 +325,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getLastName()
     {
         return $this->container['lastName'];
@@ -325,6 +338,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setLastName($lastName)
     {
         $this->container['lastName'] = $lastName;
@@ -337,6 +351,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getCompany()
     {
         return $this->container['company'];
@@ -349,6 +364,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setCompany($company)
     {
         $this->container['company'] = $company;
@@ -361,6 +377,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getJobTitle()
     {
         return $this->container['jobTitle'];
@@ -373,6 +390,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setJobTitle($jobTitle)
     {
         $this->container['jobTitle'] = $jobTitle;
@@ -385,6 +403,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getPhone()
     {
         return $this->container['phone'];
@@ -397,6 +416,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setPhone($phone)
     {
         $this->container['phone'] = $phone;
@@ -409,6 +429,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getState()
     {
         return $this->container['state'];
@@ -421,6 +442,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setState($state)
     {
         $this->container['state'] = $state;
@@ -433,6 +455,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getStreetAddress()
     {
         return $this->container['streetAddress'];
@@ -445,6 +468,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setStreetAddress($streetAddress)
     {
         $this->container['streetAddress'] = $streetAddress;
@@ -457,6 +481,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getCity()
     {
         return $this->container['city'];
@@ -469,6 +494,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setCity($city)
     {
         $this->container['city'] = $city;
@@ -481,6 +507,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getPostalCode()
     {
         return $this->container['postalCode'];
@@ -493,6 +520,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setPostalCode($postalCode)
     {
         $this->container['postalCode'] = $postalCode;
@@ -506,6 +534,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -518,6 +547,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -531,6 +561,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -547,6 +578,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -559,6 +591,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -569,6 +602,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -582,6 +616,7 @@ class ContactCreateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/ContactDetailsResponse.php
+++ b/src/Model/ContactDetailsResponse.php
@@ -96,6 +96,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -106,6 +107,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -175,6 +177,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -185,6 +188,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -195,6 +199,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -205,6 +210,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -244,6 +250,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -257,6 +264,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -268,6 +276,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -280,6 +289,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -292,6 +302,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getEmail()
     {
         return $this->container['email'];
@@ -304,6 +315,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setEmail($email)
     {
         $this->container['email'] = $email;
@@ -316,6 +328,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getFirstName()
     {
         return $this->container['firstName'];
@@ -328,6 +341,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setFirstName($firstName)
     {
         $this->container['firstName'] = $firstName;
@@ -340,6 +354,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getLastName()
     {
         return $this->container['lastName'];
@@ -352,6 +367,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setLastName($lastName)
     {
         $this->container['lastName'] = $lastName;
@@ -364,6 +380,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getCompany()
     {
         return $this->container['company'];
@@ -376,6 +393,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setCompany($company)
     {
         $this->container['company'] = $company;
@@ -388,6 +406,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getJobTitle()
     {
         return $this->container['jobTitle'];
@@ -400,6 +419,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setJobTitle($jobTitle)
     {
         $this->container['jobTitle'] = $jobTitle;
@@ -412,6 +432,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getPhone()
     {
         return $this->container['phone'];
@@ -424,6 +445,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setPhone($phone)
     {
         $this->container['phone'] = $phone;
@@ -436,6 +458,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getState()
     {
         return $this->container['state'];
@@ -448,6 +471,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setState($state)
     {
         $this->container['state'] = $state;
@@ -460,6 +484,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getStreetAddress()
     {
         return $this->container['streetAddress'];
@@ -472,6 +497,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setStreetAddress($streetAddress)
     {
         $this->container['streetAddress'] = $streetAddress;
@@ -484,6 +510,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getCity()
     {
         return $this->container['city'];
@@ -496,6 +523,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setCity($city)
     {
         $this->container['city'] = $city;
@@ -508,6 +536,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getPostalCode()
     {
         return $this->container['postalCode'];
@@ -520,6 +549,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setPostalCode($postalCode)
     {
         $this->container['postalCode'] = $postalCode;
@@ -533,6 +563,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -545,6 +576,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -558,6 +590,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -574,6 +607,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -586,6 +620,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -596,6 +631,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -609,6 +645,7 @@ class ContactDetailsResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/ContactListResponse.php
+++ b/src/Model/ContactListResponse.php
@@ -76,6 +76,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -86,6 +87,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -125,6 +127,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -135,6 +138,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -145,6 +149,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -155,6 +160,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -184,6 +190,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -197,6 +204,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -208,6 +216,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return \PandaDoc\Client\Model\ContactDetailsResponse[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getResults()
     {
         return $this->container['results'];
@@ -220,6 +229,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setResults($results)
     {
         $this->container['results'] = $results;
@@ -233,6 +243,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +256,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +270,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +287,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +300,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -296,6 +311,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -309,6 +325,7 @@ class ContactListResponse implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/ContactUpdateRequest.php
+++ b/src/Model/ContactUpdateRequest.php
@@ -94,6 +94,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -104,6 +105,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -170,6 +172,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -180,6 +183,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -190,6 +194,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -200,6 +205,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -238,6 +244,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -251,6 +258,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -262,6 +270,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getEmail()
     {
         return $this->container['email'];
@@ -274,6 +283,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setEmail($email)
     {
         $this->container['email'] = $email;
@@ -286,6 +296,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getFirstName()
     {
         return $this->container['firstName'];
@@ -298,6 +309,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setFirstName($firstName)
     {
         $this->container['firstName'] = $firstName;
@@ -310,6 +322,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getLastName()
     {
         return $this->container['lastName'];
@@ -322,6 +335,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setLastName($lastName)
     {
         $this->container['lastName'] = $lastName;
@@ -334,6 +348,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getCompany()
     {
         return $this->container['company'];
@@ -346,6 +361,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setCompany($company)
     {
         $this->container['company'] = $company;
@@ -358,6 +374,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getJobTitle()
     {
         return $this->container['jobTitle'];
@@ -370,6 +387,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setJobTitle($jobTitle)
     {
         $this->container['jobTitle'] = $jobTitle;
@@ -382,6 +400,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getPhone()
     {
         return $this->container['phone'];
@@ -394,6 +413,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setPhone($phone)
     {
         $this->container['phone'] = $phone;
@@ -406,6 +426,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getState()
     {
         return $this->container['state'];
@@ -418,6 +439,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setState($state)
     {
         $this->container['state'] = $state;
@@ -430,6 +452,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getStreetAddress()
     {
         return $this->container['streetAddress'];
@@ -442,6 +465,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setStreetAddress($streetAddress)
     {
         $this->container['streetAddress'] = $streetAddress;
@@ -454,6 +478,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getCity()
     {
         return $this->container['city'];
@@ -466,6 +491,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setCity($city)
     {
         $this->container['city'] = $city;
@@ -478,6 +504,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getPostalCode()
     {
         return $this->container['postalCode'];
@@ -490,6 +517,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setPostalCode($postalCode)
     {
         $this->container['postalCode'] = $postalCode;
@@ -503,6 +531,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -515,6 +544,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -528,6 +558,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -544,6 +575,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -556,6 +588,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -566,6 +599,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -579,6 +613,7 @@ class ContactUpdateRequest implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/ContentLibraryItemListResponse.php
+++ b/src/Model/ContentLibraryItemListResponse.php
@@ -76,6 +76,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -86,6 +87,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -125,6 +127,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -135,6 +138,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -145,6 +149,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -155,6 +160,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -184,6 +190,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -197,6 +204,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -208,6 +216,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      *
      * @return \PandaDoc\Client\Model\ContentLibraryItemListResponseResults[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getResults()
     {
         return $this->container['results'];
@@ -220,6 +229,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setResults($results)
     {
         $this->container['results'] = $results;
@@ -233,6 +243,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +256,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +270,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +287,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +300,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -296,6 +311,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -309,6 +325,7 @@ class ContentLibraryItemListResponse implements ModelInterface, ArrayAccess, \Js
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/ContentLibraryItemListResponseResults.php
+++ b/src/Model/ContentLibraryItemListResponseResults.php
@@ -84,6 +84,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -94,6 +95,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -145,6 +147,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -155,6 +158,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -165,6 +169,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -175,6 +180,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -208,6 +214,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -221,6 +228,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -232,6 +240,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -244,6 +253,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -256,6 +266,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -268,6 +279,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -280,6 +292,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateCreated()
     {
         return $this->container['dateCreated'];
@@ -292,6 +305,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateCreated($dateCreated)
     {
         $this->container['dateCreated'] = $dateCreated;
@@ -304,6 +318,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateModified()
     {
         return $this->container['dateModified'];
@@ -316,6 +331,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateModified($dateModified)
     {
         $this->container['dateModified'] = $dateModified;
@@ -328,6 +344,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getVersion()
     {
         return $this->container['version'];
@@ -340,6 +357,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setVersion($version)
     {
         $this->container['version'] = $version;
@@ -353,6 +371,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -365,6 +384,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -378,6 +398,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -394,6 +415,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -406,6 +428,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -416,6 +439,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -429,6 +453,7 @@ class ContentLibraryItemListResponseResults implements ModelInterface, ArrayAcce
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/ContentLibraryItemResponse.php
+++ b/src/Model/ContentLibraryItemResponse.php
@@ -102,6 +102,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -112,6 +113,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -190,6 +192,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -200,6 +203,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -210,6 +214,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -220,6 +225,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -262,6 +268,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -275,6 +282,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -286,6 +294,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -298,6 +307,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -310,6 +320,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -322,6 +333,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -334,6 +346,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateCreated()
     {
         return $this->container['dateCreated'];
@@ -346,6 +359,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateCreated($dateCreated)
     {
         $this->container['dateCreated'] = $dateCreated;
@@ -358,6 +372,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateModified()
     {
         return $this->container['dateModified'];
@@ -370,6 +385,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateModified($dateModified)
     {
         $this->container['dateModified'] = $dateModified;
@@ -382,6 +398,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return \PandaDoc\Client\Model\ContentLibraryItemResponseCreatedBy|null
      */
+    #[\ReturnTypeWillChange]
     public function getCreatedBy()
     {
         return $this->container['createdBy'];
@@ -394,6 +411,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setCreatedBy($createdBy)
     {
         $this->container['createdBy'] = $createdBy;
@@ -406,6 +424,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getMetadata()
     {
         return $this->container['metadata'];
@@ -418,6 +437,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setMetadata($metadata)
     {
         $this->container['metadata'] = $metadata;
@@ -430,6 +450,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return object[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getTokens()
     {
         return $this->container['tokens'];
@@ -442,6 +463,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTokens($tokens)
     {
         $this->container['tokens'] = $tokens;
@@ -454,6 +476,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return object[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getFields()
     {
         return $this->container['fields'];
@@ -466,6 +489,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setFields($fields)
     {
         $this->container['fields'] = $fields;
@@ -478,6 +502,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return \PandaDoc\Client\Model\PricingTablesResponse|null
      */
+    #[\ReturnTypeWillChange]
     public function getPricing()
     {
         return $this->container['pricing'];
@@ -490,6 +515,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setPricing($pricing)
     {
         $this->container['pricing'] = $pricing;
@@ -502,6 +528,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getTags()
     {
         return $this->container['tags'];
@@ -514,6 +541,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTags($tags)
     {
         $this->container['tags'] = $tags;
@@ -526,6 +554,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return object[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getRoles()
     {
         return $this->container['roles'];
@@ -538,6 +567,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setRoles($roles)
     {
         $this->container['roles'] = $roles;
@@ -550,6 +580,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getVersion()
     {
         return $this->container['version'];
@@ -562,6 +593,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setVersion($version)
     {
         $this->container['version'] = $version;
@@ -574,6 +606,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return object[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getContentPlaceholders()
     {
         return $this->container['contentPlaceholders'];
@@ -586,6 +619,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setContentPlaceholders($contentPlaceholders)
     {
         $this->container['contentPlaceholders'] = $contentPlaceholders;
@@ -598,6 +632,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return object[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getImages()
     {
         return $this->container['images'];
@@ -610,6 +645,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setImages($images)
     {
         $this->container['images'] = $images;
@@ -623,6 +659,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -635,6 +672,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -648,6 +686,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -664,6 +703,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -676,6 +716,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -686,6 +727,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -699,6 +741,7 @@ class ContentLibraryItemResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/ContentLibraryItemResponseCreatedBy.php
+++ b/src/Model/ContentLibraryItemResponseCreatedBy.php
@@ -84,6 +84,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -94,6 +95,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -145,6 +147,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -155,6 +158,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -165,6 +169,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -175,6 +180,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -208,6 +214,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -221,6 +228,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -232,6 +240,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -244,6 +253,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -256,6 +266,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getEmail()
     {
         return $this->container['email'];
@@ -268,6 +279,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setEmail($email)
     {
         $this->container['email'] = $email;
@@ -280,6 +292,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getFirstName()
     {
         return $this->container['firstName'];
@@ -292,6 +305,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setFirstName($firstName)
     {
         $this->container['firstName'] = $firstName;
@@ -304,6 +318,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getLastName()
     {
         return $this->container['lastName'];
@@ -316,6 +331,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setLastName($lastName)
     {
         $this->container['lastName'] = $lastName;
@@ -328,6 +344,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getAvatar()
     {
         return $this->container['avatar'];
@@ -340,6 +357,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setAvatar($avatar)
     {
         $this->container['avatar'] = $avatar;
@@ -353,6 +371,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -365,6 +384,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -378,6 +398,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -394,6 +415,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -406,6 +428,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -416,6 +439,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -429,6 +453,7 @@ class ContentLibraryItemResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentAttachmentResponse.php
+++ b/src/Model/DocumentAttachmentResponse.php
@@ -82,6 +82,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -92,6 +93,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -140,6 +142,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -150,6 +153,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -160,6 +164,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -170,6 +175,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -202,6 +208,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -215,6 +222,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -226,6 +234,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getUuid()
     {
         return $this->container['uuid'];
@@ -238,6 +247,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUuid($uuid)
     {
         $this->container['uuid'] = $uuid;
@@ -250,6 +260,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateCreated()
     {
         return $this->container['dateCreated'];
@@ -262,6 +273,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateCreated($dateCreated)
     {
         $this->container['dateCreated'] = $dateCreated;
@@ -274,6 +286,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return \PandaDoc\Client\Model\DocumentAttachmentResponseCreatedBy|null
      */
+    #[\ReturnTypeWillChange]
     public function getCreatedBy()
     {
         return $this->container['createdBy'];
@@ -286,6 +299,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setCreatedBy($createdBy)
     {
         $this->container['createdBy'] = $createdBy;
@@ -298,6 +312,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -310,6 +325,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -323,6 +339,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -335,6 +352,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -348,6 +366,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -364,6 +383,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -376,6 +396,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -386,6 +407,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -399,6 +421,7 @@ class DocumentAttachmentResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentAttachmentResponseCreatedBy.php
+++ b/src/Model/DocumentAttachmentResponseCreatedBy.php
@@ -84,6 +84,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -94,6 +95,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -145,6 +147,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -155,6 +158,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -165,6 +169,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -175,6 +180,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -208,6 +214,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -221,6 +228,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -232,6 +240,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -244,6 +253,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -256,6 +266,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getEmail()
     {
         return $this->container['email'];
@@ -268,6 +279,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setEmail($email)
     {
         $this->container['email'] = $email;
@@ -280,6 +292,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getFirstName()
     {
         return $this->container['firstName'];
@@ -292,6 +305,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setFirstName($firstName)
     {
         $this->container['firstName'] = $firstName;
@@ -304,6 +318,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getLastName()
     {
         return $this->container['lastName'];
@@ -316,6 +331,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setLastName($lastName)
     {
         $this->container['lastName'] = $lastName;
@@ -328,6 +344,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getAvatar()
     {
         return $this->container['avatar'];
@@ -340,6 +357,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setAvatar($avatar)
     {
         $this->container['avatar'] = $avatar;
@@ -353,6 +371,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -365,6 +384,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -378,6 +398,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -394,6 +415,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -406,6 +428,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -416,6 +439,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -429,6 +453,7 @@ class DocumentAttachmentResponseCreatedBy implements ModelInterface, ArrayAccess
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentCreateByPdfRequest.php
+++ b/src/Model/DocumentCreateByPdfRequest.php
@@ -88,6 +88,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -98,6 +99,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -155,6 +157,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -165,6 +168,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -175,6 +179,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -185,6 +190,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -220,6 +226,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -239,6 +246,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -250,6 +258,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getUrl()
     {
         return $this->container['url'];
@@ -262,6 +271,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUrl($url)
     {
         $this->container['url'] = $url;
@@ -274,6 +284,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return \PandaDoc\Client\Model\DocumentCreateByTemplateRequestRecipients[]
      */
+    #[\ReturnTypeWillChange]
     public function getRecipients()
     {
         return $this->container['recipients'];
@@ -286,6 +297,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setRecipients($recipients)
     {
         $this->container['recipients'] = $recipients;
@@ -298,6 +310,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getParseFormFields()
     {
         return $this->container['parseFormFields'];
@@ -310,6 +323,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setParseFormFields($parseFormFields)
     {
         $this->container['parseFormFields'] = $parseFormFields;
@@ -322,6 +336,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -334,6 +349,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -346,6 +362,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getTags()
     {
         return $this->container['tags'];
@@ -358,6 +375,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTags($tags)
     {
         $this->container['tags'] = $tags;
@@ -370,6 +388,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getFields()
     {
         return $this->container['fields'];
@@ -382,6 +401,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setFields($fields)
     {
         $this->container['fields'] = $fields;
@@ -394,6 +414,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getMetadata()
     {
         return $this->container['metadata'];
@@ -406,6 +427,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setMetadata($metadata)
     {
         $this->container['metadata'] = $metadata;
@@ -419,6 +441,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -431,6 +454,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -444,6 +468,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -460,6 +485,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -472,6 +498,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -482,6 +509,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -495,6 +523,7 @@ class DocumentCreateByPdfRequest implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentCreateByTemplateRequest.php
+++ b/src/Model/DocumentCreateByTemplateRequest.php
@@ -96,6 +96,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -106,6 +107,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -175,6 +177,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -185,6 +188,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -195,6 +199,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -205,6 +210,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -244,6 +250,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -266,6 +273,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -277,6 +285,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -289,6 +298,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -301,6 +311,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getTemplateUuid()
     {
         return $this->container['templateUuid'];
@@ -313,6 +324,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTemplateUuid($templateUuid)
     {
         $this->container['templateUuid'] = $templateUuid;
@@ -325,6 +337,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getFolderUuid()
     {
         return $this->container['folderUuid'];
@@ -337,6 +350,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setFolderUuid($folderUuid)
     {
         $this->container['folderUuid'] = $folderUuid;
@@ -349,6 +363,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return \PandaDoc\Client\Model\DocumentCreateByTemplateRequestRecipients[]
      */
+    #[\ReturnTypeWillChange]
     public function getRecipients()
     {
         return $this->container['recipients'];
@@ -361,6 +376,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setRecipients($recipients)
     {
         $this->container['recipients'] = $recipients;
@@ -373,6 +389,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return \PandaDoc\Client\Model\DocumentCreateByTemplateRequestTokens[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getTokens()
     {
         return $this->container['tokens'];
@@ -385,6 +402,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTokens($tokens)
     {
         $this->container['tokens'] = $tokens;
@@ -397,6 +415,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getFields()
     {
         return $this->container['fields'];
@@ -409,6 +428,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setFields($fields)
     {
         $this->container['fields'] = $fields;
@@ -421,6 +441,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getMetadata()
     {
         return $this->container['metadata'];
@@ -433,6 +454,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setMetadata($metadata)
     {
         $this->container['metadata'] = $metadata;
@@ -445,6 +467,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return string[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getTags()
     {
         return $this->container['tags'];
@@ -457,6 +480,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTags($tags)
     {
         $this->container['tags'] = $tags;
@@ -469,6 +493,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return \PandaDoc\Client\Model\DocumentCreateByTemplateRequestImages[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getImages()
     {
         return $this->container['images'];
@@ -481,6 +506,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setImages($images)
     {
         $this->container['images'] = $images;
@@ -493,6 +519,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return \PandaDoc\Client\Model\PricingTableRequest[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getPricingTables()
     {
         return $this->container['pricingTables'];
@@ -505,6 +532,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setPricingTables($pricingTables)
     {
         $this->container['pricingTables'] = $pricingTables;
@@ -517,6 +545,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return \PandaDoc\Client\Model\DocumentCreateByTemplateRequestContentPlaceholders[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getContentPlaceholders()
     {
         return $this->container['contentPlaceholders'];
@@ -529,6 +558,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setContentPlaceholders($contentPlaceholders)
     {
         $this->container['contentPlaceholders'] = $contentPlaceholders;
@@ -542,6 +572,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -554,6 +585,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -567,6 +599,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -583,6 +616,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -595,6 +629,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -605,6 +640,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -618,6 +654,7 @@ class DocumentCreateByTemplateRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentCreateByTemplateRequestContentLibraryItems.php
+++ b/src/Model/DocumentCreateByTemplateRequestContentLibraryItems.php
@@ -82,6 +82,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -92,6 +93,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -140,6 +142,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -150,6 +153,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -160,6 +164,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -170,6 +175,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -202,6 +208,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -218,6 +225,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -229,6 +237,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -241,6 +250,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -253,6 +263,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getFields()
     {
         return $this->container['fields'];
@@ -265,6 +276,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setFields($fields)
     {
         $this->container['fields'] = $fields;
@@ -277,6 +289,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return \PandaDoc\Client\Model\PricingTableRequest[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getPricingTables()
     {
         return $this->container['pricingTables'];
@@ -289,6 +302,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setPricingTables($pricingTables)
     {
         $this->container['pricingTables'] = $pricingTables;
@@ -301,6 +315,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return \PandaDoc\Client\Model\DocumentCreateByTemplateRequestRecipients[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getRecipients()
     {
         return $this->container['recipients'];
@@ -313,6 +328,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setRecipients($recipients)
     {
         $this->container['recipients'] = $recipients;
@@ -326,6 +342,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -338,6 +355,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -351,6 +369,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -367,6 +386,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -379,6 +399,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -389,6 +410,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -402,6 +424,7 @@ class DocumentCreateByTemplateRequestContentLibraryItems implements ModelInterfa
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentCreateByTemplateRequestContentPlaceholders.php
+++ b/src/Model/DocumentCreateByTemplateRequestContentPlaceholders.php
@@ -78,6 +78,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -88,6 +89,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -130,6 +132,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -140,6 +143,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -150,6 +154,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -160,6 +165,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -190,6 +196,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -206,6 +213,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -217,6 +225,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return \PandaDoc\Client\Model\DocumentCreateByTemplateRequestContentLibraryItems[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getContentLibraryItems()
     {
         return $this->container['contentLibraryItems'];
@@ -229,6 +238,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setContentLibraryItems($contentLibraryItems)
     {
         $this->container['contentLibraryItems'] = $contentLibraryItems;
@@ -241,6 +251,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getBlockId()
     {
         return $this->container['blockId'];
@@ -253,6 +264,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setBlockId($blockId)
     {
         $this->container['blockId'] = $blockId;
@@ -266,6 +278,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -278,6 +291,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -291,6 +305,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -307,6 +322,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -319,6 +335,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -329,6 +346,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -342,6 +360,7 @@ class DocumentCreateByTemplateRequestContentPlaceholders implements ModelInterfa
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentCreateByTemplateRequestImages.php
+++ b/src/Model/DocumentCreateByTemplateRequestImages.php
@@ -78,6 +78,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -88,6 +89,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -130,6 +132,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -140,6 +143,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -150,6 +154,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -160,6 +165,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -190,6 +196,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -209,6 +216,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -220,6 +228,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return string[]
      */
+    #[\ReturnTypeWillChange]
     public function getUrls()
     {
         return $this->container['urls'];
@@ -232,6 +241,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUrls($urls)
     {
         $this->container['urls'] = $urls;
@@ -244,6 +254,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -256,6 +267,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -269,6 +281,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -281,6 +294,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -294,6 +308,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -310,6 +325,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -322,6 +338,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -332,6 +349,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -345,6 +363,7 @@ class DocumentCreateByTemplateRequestImages implements ModelInterface, ArrayAcce
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentCreateByTemplateRequestRecipients.php
+++ b/src/Model/DocumentCreateByTemplateRequestRecipients.php
@@ -84,6 +84,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -94,6 +95,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -145,6 +147,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -155,6 +158,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -165,6 +169,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -175,6 +180,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -208,6 +214,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -224,6 +231,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -235,6 +243,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getEmail()
     {
         return $this->container['email'];
@@ -247,6 +256,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setEmail($email)
     {
         $this->container['email'] = $email;
@@ -259,6 +269,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getFirstName()
     {
         return $this->container['firstName'];
@@ -271,6 +282,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setFirstName($firstName)
     {
         $this->container['firstName'] = $firstName;
@@ -283,6 +295,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getLastName()
     {
         return $this->container['lastName'];
@@ -295,6 +308,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setLastName($lastName)
     {
         $this->container['lastName'] = $lastName;
@@ -307,6 +321,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getRole()
     {
         return $this->container['role'];
@@ -319,6 +334,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setRole($role)
     {
         $this->container['role'] = $role;
@@ -331,6 +347,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return int|null
      */
+    #[\ReturnTypeWillChange]
     public function getSigningOrder()
     {
         return $this->container['signingOrder'];
@@ -343,6 +360,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setSigningOrder($signingOrder)
     {
         $this->container['signingOrder'] = $signingOrder;
@@ -356,6 +374,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -368,6 +387,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -381,6 +401,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -397,6 +418,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -409,6 +431,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -419,6 +442,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -432,6 +456,7 @@ class DocumentCreateByTemplateRequestRecipients implements ModelInterface, Array
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentCreateByTemplateRequestTokens.php
+++ b/src/Model/DocumentCreateByTemplateRequestTokens.php
@@ -78,6 +78,7 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -88,6 +89,7 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -130,6 +132,7 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -140,6 +143,7 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -150,6 +154,7 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -160,6 +165,7 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -190,6 +196,7 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -209,6 +216,7 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -220,6 +228,7 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -232,6 +241,7 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -244,6 +254,7 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getValue()
     {
         return $this->container['value'];
@@ -256,6 +267,7 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setValue($value)
     {
         $this->container['value'] = $value;
@@ -269,6 +281,7 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -281,6 +294,7 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -294,6 +308,7 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -310,6 +325,7 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -322,6 +338,7 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -332,6 +349,7 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -345,6 +363,7 @@ class DocumentCreateByTemplateRequestTokens implements ModelInterface, ArrayAcce
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentCreateLinkRequest.php
+++ b/src/Model/DocumentCreateLinkRequest.php
@@ -78,6 +78,7 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -88,6 +89,7 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -130,6 +132,7 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -140,6 +143,7 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -150,6 +154,7 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -160,6 +165,7 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -190,6 +196,7 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -206,6 +213,7 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -217,6 +225,7 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getRecipient()
     {
         return $this->container['recipient'];
@@ -229,6 +238,7 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setRecipient($recipient)
     {
         $this->container['recipient'] = $recipient;
@@ -241,6 +251,7 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return float|null
      */
+    #[\ReturnTypeWillChange]
     public function getLifetime()
     {
         return $this->container['lifetime'];
@@ -253,6 +264,7 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setLifetime($lifetime)
     {
         $this->container['lifetime'] = $lifetime;
@@ -266,6 +278,7 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -278,6 +291,7 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -291,6 +305,7 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -307,6 +322,7 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -319,6 +335,7 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -329,6 +346,7 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -342,6 +360,7 @@ class DocumentCreateLinkRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentCreateLinkResponse.php
+++ b/src/Model/DocumentCreateLinkResponse.php
@@ -78,6 +78,7 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -88,6 +89,7 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -130,6 +132,7 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -140,6 +143,7 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -150,6 +154,7 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -160,6 +165,7 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -190,6 +196,7 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -203,6 +210,7 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -214,6 +222,7 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -226,6 +235,7 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -238,6 +248,7 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getExpiresAt()
     {
         return $this->container['expiresAt'];
@@ -250,6 +261,7 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setExpiresAt($expiresAt)
     {
         $this->container['expiresAt'] = $expiresAt;
@@ -263,6 +275,7 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -275,6 +288,7 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -288,6 +302,7 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -304,6 +319,7 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -316,6 +332,7 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -326,6 +343,7 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -339,6 +357,7 @@ class DocumentCreateLinkResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentCreateRequest.php
+++ b/src/Model/DocumentCreateRequest.php
@@ -102,6 +102,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -112,6 +113,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -190,6 +192,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -200,6 +203,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -210,6 +214,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -220,6 +225,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -262,6 +268,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -275,6 +282,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -286,6 +294,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -298,6 +307,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -310,6 +320,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getTemplateUuid()
     {
         return $this->container['templateUuid'];
@@ -322,6 +333,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTemplateUuid($templateUuid)
     {
         $this->container['templateUuid'] = $templateUuid;
@@ -334,6 +346,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getFolderUuid()
     {
         return $this->container['folderUuid'];
@@ -346,6 +359,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setFolderUuid($folderUuid)
     {
         $this->container['folderUuid'] = $folderUuid;
@@ -358,6 +372,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array<string,string>|null
      */
+    #[\ReturnTypeWillChange]
     public function getOwner()
     {
         return $this->container['owner'];
@@ -370,6 +385,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setOwner($owner)
     {
         $this->container['owner'] = $owner;
@@ -382,6 +398,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return \PandaDoc\Client\Model\DocumentCreateRequestRecipients[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getRecipients()
     {
         return $this->container['recipients'];
@@ -394,6 +411,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setRecipients($recipients)
     {
         $this->container['recipients'] = $recipients;
@@ -406,6 +424,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return \PandaDoc\Client\Model\DocumentCreateByTemplateRequestTokens[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getTokens()
     {
         return $this->container['tokens'];
@@ -418,6 +437,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTokens($tokens)
     {
         $this->container['tokens'] = $tokens;
@@ -430,6 +450,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getFields()
     {
         return $this->container['fields'];
@@ -442,6 +463,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setFields($fields)
     {
         $this->container['fields'] = $fields;
@@ -454,6 +476,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getMetadata()
     {
         return $this->container['metadata'];
@@ -466,6 +489,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setMetadata($metadata)
     {
         $this->container['metadata'] = $metadata;
@@ -478,6 +502,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getTags()
     {
         return $this->container['tags'];
@@ -490,6 +515,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTags($tags)
     {
         $this->container['tags'] = $tags;
@@ -502,6 +528,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return \PandaDoc\Client\Model\DocumentCreateRequestImages[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getImages()
     {
         return $this->container['images'];
@@ -514,6 +541,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setImages($images)
     {
         $this->container['images'] = $images;
@@ -526,6 +554,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return \PandaDoc\Client\Model\PricingTableRequest[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getPricingTables()
     {
         return $this->container['pricingTables'];
@@ -538,6 +567,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setPricingTables($pricingTables)
     {
         $this->container['pricingTables'] = $pricingTables;
@@ -550,6 +580,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return \PandaDoc\Client\Model\DocumentCreateRequestContentPlaceholders[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getContentPlaceholders()
     {
         return $this->container['contentPlaceholders'];
@@ -562,6 +593,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setContentPlaceholders($contentPlaceholders)
     {
         $this->container['contentPlaceholders'] = $contentPlaceholders;
@@ -574,6 +606,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getUrl()
     {
         return $this->container['url'];
@@ -586,6 +619,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUrl($url)
     {
         $this->container['url'] = $url;
@@ -598,6 +632,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getParseFormFields()
     {
         return $this->container['parseFormFields'];
@@ -610,6 +645,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setParseFormFields($parseFormFields)
     {
         $this->container['parseFormFields'] = $parseFormFields;
@@ -623,6 +659,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -635,6 +672,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -648,6 +686,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -664,6 +703,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -676,6 +716,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -686,6 +727,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -699,6 +741,7 @@ class DocumentCreateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentCreateRequestContentLibraryItems.php
+++ b/src/Model/DocumentCreateRequestContentLibraryItems.php
@@ -82,6 +82,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -92,6 +93,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -140,6 +142,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -150,6 +153,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -160,6 +164,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -170,6 +175,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -202,6 +208,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -218,6 +225,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -229,6 +237,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -241,6 +250,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -253,6 +263,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return \PandaDoc\Client\Model\PricingTableRequest[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getPricingTables()
     {
         return $this->container['pricingTables'];
@@ -265,6 +276,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setPricingTables($pricingTables)
     {
         $this->container['pricingTables'] = $pricingTables;
@@ -277,6 +289,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getFields()
     {
         return $this->container['fields'];
@@ -289,6 +302,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setFields($fields)
     {
         $this->container['fields'] = $fields;
@@ -301,6 +315,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return \PandaDoc\Client\Model\DocumentCreateByTemplateRequestRecipients[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getRecipients()
     {
         return $this->container['recipients'];
@@ -313,6 +328,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setRecipients($recipients)
     {
         $this->container['recipients'] = $recipients;
@@ -326,6 +342,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -338,6 +355,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -351,6 +369,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -367,6 +386,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -379,6 +399,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -389,6 +410,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -402,6 +424,7 @@ class DocumentCreateRequestContentLibraryItems implements ModelInterface, ArrayA
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentCreateRequestContentPlaceholders.php
+++ b/src/Model/DocumentCreateRequestContentPlaceholders.php
@@ -78,6 +78,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -88,6 +89,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -130,6 +132,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -140,6 +143,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -150,6 +154,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -160,6 +165,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -190,6 +196,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -203,6 +210,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -214,6 +222,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getBlockId()
     {
         return $this->container['blockId'];
@@ -226,6 +235,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setBlockId($blockId)
     {
         $this->container['blockId'] = $blockId;
@@ -238,6 +248,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return \PandaDoc\Client\Model\DocumentCreateRequestContentLibraryItems[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getContentLibraryItems()
     {
         return $this->container['contentLibraryItems'];
@@ -250,6 +261,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setContentLibraryItems($contentLibraryItems)
     {
         $this->container['contentLibraryItems'] = $contentLibraryItems;
@@ -263,6 +275,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -275,6 +288,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -288,6 +302,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -304,6 +319,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -316,6 +332,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -326,6 +343,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -339,6 +357,7 @@ class DocumentCreateRequestContentPlaceholders implements ModelInterface, ArrayA
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentCreateRequestImages.php
+++ b/src/Model/DocumentCreateRequestImages.php
@@ -78,6 +78,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -88,6 +89,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -130,6 +132,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -140,6 +143,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -150,6 +154,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -160,6 +165,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -190,6 +196,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -209,6 +216,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -220,6 +228,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string[]
      */
+    #[\ReturnTypeWillChange]
     public function getUrls()
     {
         return $this->container['urls'];
@@ -232,6 +241,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUrls($urls)
     {
         $this->container['urls'] = $urls;
@@ -244,6 +254,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -256,6 +267,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -269,6 +281,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -281,6 +294,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -294,6 +308,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -310,6 +325,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -322,6 +338,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -332,6 +349,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -345,6 +363,7 @@ class DocumentCreateRequestImages implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentCreateRequestRecipients.php
+++ b/src/Model/DocumentCreateRequestRecipients.php
@@ -84,6 +84,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -94,6 +95,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -145,6 +147,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -155,6 +158,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -165,6 +169,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -175,6 +180,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -208,6 +214,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -224,6 +231,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -235,6 +243,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getEmail()
     {
         return $this->container['email'];
@@ -247,6 +256,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setEmail($email)
     {
         $this->container['email'] = $email;
@@ -259,6 +269,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getFirstName()
     {
         return $this->container['firstName'];
@@ -271,6 +282,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setFirstName($firstName)
     {
         $this->container['firstName'] = $firstName;
@@ -283,6 +295,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getLastName()
     {
         return $this->container['lastName'];
@@ -295,6 +308,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setLastName($lastName)
     {
         $this->container['lastName'] = $lastName;
@@ -307,6 +321,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getRole()
     {
         return $this->container['role'];
@@ -319,6 +334,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setRole($role)
     {
         $this->container['role'] = $role;
@@ -331,6 +347,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return int|null
      */
+    #[\ReturnTypeWillChange]
     public function getSigningOrder()
     {
         return $this->container['signingOrder'];
@@ -343,6 +360,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setSigningOrder($signingOrder)
     {
         $this->container['signingOrder'] = $signingOrder;
@@ -356,6 +374,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -368,6 +387,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -381,6 +401,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -397,6 +418,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -409,6 +431,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -419,6 +442,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -432,6 +456,7 @@ class DocumentCreateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentCreateResponse.php
+++ b/src/Model/DocumentCreateResponse.php
@@ -92,6 +92,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -102,6 +103,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -165,6 +167,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -175,6 +178,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -185,6 +189,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -195,6 +200,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -232,6 +238,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -245,6 +252,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -256,6 +264,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -268,6 +277,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -280,6 +290,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -292,6 +303,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -304,6 +316,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return \PandaDoc\Client\Model\DocumentStatusEnum|null
      */
+    #[\ReturnTypeWillChange]
     public function getStatus()
     {
         return $this->container['status'];
@@ -316,6 +329,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setStatus($status)
     {
         $this->container['status'] = $status;
@@ -328,6 +342,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateCreated()
     {
         return $this->container['dateCreated'];
@@ -340,6 +355,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateCreated($dateCreated)
     {
         $this->container['dateCreated'] = $dateCreated;
@@ -352,6 +368,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateModified()
     {
         return $this->container['dateModified'];
@@ -364,6 +381,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateModified($dateModified)
     {
         $this->container['dateModified'] = $dateModified;
@@ -376,6 +394,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getExpirationDate()
     {
         return $this->container['expirationDate'];
@@ -388,6 +407,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setExpirationDate($expirationDate)
     {
         $this->container['expirationDate'] = $expirationDate;
@@ -400,6 +420,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getUuid()
     {
         return $this->container['uuid'];
@@ -412,6 +433,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUuid($uuid)
     {
         $this->container['uuid'] = $uuid;
@@ -424,6 +446,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return \PandaDoc\Client\Model\DocumentCreateResponseLinks[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getLinks()
     {
         return $this->container['links'];
@@ -436,6 +459,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setLinks($links)
     {
         $this->container['links'] = $links;
@@ -448,6 +472,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getInfoMessage()
     {
         return $this->container['infoMessage'];
@@ -460,6 +485,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setInfoMessage($infoMessage)
     {
         $this->container['infoMessage'] = $infoMessage;
@@ -473,6 +499,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -485,6 +512,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -498,6 +526,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -514,6 +543,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -526,6 +556,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -536,6 +567,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -549,6 +581,7 @@ class DocumentCreateResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentCreateResponseLinks.php
+++ b/src/Model/DocumentCreateResponseLinks.php
@@ -80,6 +80,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -90,6 +91,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -135,6 +137,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -145,6 +148,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -155,6 +159,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -165,6 +170,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -196,6 +202,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -209,6 +216,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -220,6 +228,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getRel()
     {
         return $this->container['rel'];
@@ -232,6 +241,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setRel($rel)
     {
         $this->container['rel'] = $rel;
@@ -244,6 +254,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getHref()
     {
         return $this->container['href'];
@@ -256,6 +267,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setHref($href)
     {
         $this->container['href'] = $href;
@@ -268,6 +280,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getType()
     {
         return $this->container['type'];
@@ -280,6 +293,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setType($type)
     {
         $this->container['type'] = $type;
@@ -293,6 +307,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -305,6 +320,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -318,6 +334,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -334,6 +351,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -346,6 +364,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -356,6 +375,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -369,6 +389,7 @@ class DocumentCreateResponseLinks implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentDetailsResponse.php
+++ b/src/Model/DocumentDetailsResponse.php
@@ -114,6 +114,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -124,6 +125,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -220,6 +222,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -230,6 +233,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -240,6 +244,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -250,6 +255,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -298,6 +304,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -311,6 +318,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -322,6 +330,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -334,6 +343,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -346,6 +356,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -358,6 +369,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -370,6 +382,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function getAutonumberingSequenceNamePrefix()
     {
         return $this->container['autonumberingSequenceNamePrefix'];
@@ -382,6 +395,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setAutonumberingSequenceNamePrefix($autonumberingSequenceNamePrefix)
     {
         $this->container['autonumberingSequenceNamePrefix'] = $autonumberingSequenceNamePrefix;
@@ -394,6 +408,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateCreated()
     {
         return $this->container['dateCreated'];
@@ -406,6 +421,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateCreated($dateCreated)
     {
         $this->container['dateCreated'] = $dateCreated;
@@ -418,6 +434,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateModified()
     {
         return $this->container['dateModified'];
@@ -430,6 +447,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateModified($dateModified)
     {
         $this->container['dateModified'] = $dateModified;
@@ -442,6 +460,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateCompleted()
     {
         return $this->container['dateCompleted'];
@@ -454,6 +473,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateCompleted($dateCompleted)
     {
         $this->container['dateCompleted'] = $dateCompleted;
@@ -466,6 +486,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return \PandaDoc\Client\Model\DocumentDetailsResponseCreatedBy|null
      */
+    #[\ReturnTypeWillChange]
     public function getCreatedBy()
     {
         return $this->container['createdBy'];
@@ -478,6 +499,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setCreatedBy($createdBy)
     {
         $this->container['createdBy'] = $createdBy;
@@ -490,6 +512,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return \PandaDoc\Client\Model\DocumentDetailsResponseTemplate|null
      */
+    #[\ReturnTypeWillChange]
     public function getTemplate()
     {
         return $this->container['template'];
@@ -502,6 +525,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTemplate($template)
     {
         $this->container['template'] = $template;
@@ -514,6 +538,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function getExpirationDate()
     {
         return $this->container['expirationDate'];
@@ -526,6 +551,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setExpirationDate($expirationDate)
     {
         $this->container['expirationDate'] = $expirationDate;
@@ -538,6 +564,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getMetadata()
     {
         return $this->container['metadata'];
@@ -550,6 +577,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setMetadata($metadata)
     {
         $this->container['metadata'] = $metadata;
@@ -562,6 +590,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return object[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getTokens()
     {
         return $this->container['tokens'];
@@ -574,6 +603,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTokens($tokens)
     {
         $this->container['tokens'] = $tokens;
@@ -586,6 +616,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return object[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getFields()
     {
         return $this->container['fields'];
@@ -598,6 +629,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setFields($fields)
     {
         $this->container['fields'] = $fields;
@@ -610,6 +642,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return \PandaDoc\Client\Model\PricingTablesResponse|null
      */
+    #[\ReturnTypeWillChange]
     public function getPricing()
     {
         return $this->container['pricing'];
@@ -622,6 +655,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setPricing($pricing)
     {
         $this->container['pricing'] = $pricing;
@@ -634,6 +668,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getVersion()
     {
         return $this->container['version'];
@@ -646,6 +681,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setVersion($version)
     {
         $this->container['version'] = $version;
@@ -658,6 +694,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getTags()
     {
         return $this->container['tags'];
@@ -670,6 +707,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTags($tags)
     {
         $this->container['tags'] = $tags;
@@ -682,6 +720,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function getSentBy()
     {
         return $this->container['sentBy'];
@@ -694,6 +733,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setSentBy($sentBy)
     {
         $this->container['sentBy'] = $sentBy;
@@ -706,6 +746,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return \PandaDoc\Client\Model\DocumentDetailsResponseRecipients[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getRecipients()
     {
         return $this->container['recipients'];
@@ -718,6 +759,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setRecipients($recipients)
     {
         $this->container['recipients'] = $recipients;
@@ -730,6 +772,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return \PandaDoc\Client\Model\DocumentDetailsResponseGrandTotal|null
      */
+    #[\ReturnTypeWillChange]
     public function getGrandTotal()
     {
         return $this->container['grandTotal'];
@@ -742,6 +785,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setGrandTotal($grandTotal)
     {
         $this->container['grandTotal'] = $grandTotal;
@@ -754,6 +798,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return \PandaDoc\Client\Model\DocumentDetailsResponseLinkedObjects[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getLinkedObjects()
     {
         return $this->container['linkedObjects'];
@@ -766,6 +811,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setLinkedObjects($linkedObjects)
     {
         $this->container['linkedObjects'] = $linkedObjects;
@@ -778,6 +824,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getStatus()
     {
         return $this->container['status'];
@@ -790,6 +837,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setStatus($status)
     {
         $this->container['status'] = $status;
@@ -803,6 +851,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -815,6 +864,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -828,6 +878,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -844,6 +895,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -856,6 +908,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -866,6 +919,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -879,6 +933,7 @@ class DocumentDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentDetailsResponseCreatedBy.php
+++ b/src/Model/DocumentDetailsResponseCreatedBy.php
@@ -86,6 +86,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -96,6 +97,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -150,6 +152,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -160,6 +163,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -170,6 +174,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -180,6 +185,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -214,6 +220,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -227,6 +234,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -238,6 +246,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -250,6 +259,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -262,6 +272,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getMembershipId()
     {
         return $this->container['membershipId'];
@@ -274,6 +285,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setMembershipId($membershipId)
     {
         $this->container['membershipId'] = $membershipId;
@@ -286,6 +298,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getEmail()
     {
         return $this->container['email'];
@@ -298,6 +311,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setEmail($email)
     {
         $this->container['email'] = $email;
@@ -310,6 +324,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getFirstName()
     {
         return $this->container['firstName'];
@@ -322,6 +337,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setFirstName($firstName)
     {
         $this->container['firstName'] = $firstName;
@@ -334,6 +350,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getLastName()
     {
         return $this->container['lastName'];
@@ -346,6 +363,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setLastName($lastName)
     {
         $this->container['lastName'] = $lastName;
@@ -358,6 +376,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getAvatar()
     {
         return $this->container['avatar'];
@@ -370,6 +389,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setAvatar($avatar)
     {
         $this->container['avatar'] = $avatar;
@@ -383,6 +403,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -395,6 +416,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -408,6 +430,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -424,6 +447,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -436,6 +460,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -446,6 +471,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -459,6 +485,7 @@ class DocumentDetailsResponseCreatedBy implements ModelInterface, ArrayAccess, \
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentDetailsResponseGrandTotal.php
+++ b/src/Model/DocumentDetailsResponseGrandTotal.php
@@ -78,6 +78,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -88,6 +89,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -130,6 +132,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -140,6 +143,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -150,6 +154,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -160,6 +165,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -190,6 +196,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -203,6 +210,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -214,6 +222,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getAmount()
     {
         return $this->container['amount'];
@@ -226,6 +235,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setAmount($amount)
     {
         $this->container['amount'] = $amount;
@@ -238,6 +248,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getCurrency()
     {
         return $this->container['currency'];
@@ -250,6 +261,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setCurrency($currency)
     {
         $this->container['currency'] = $currency;
@@ -263,6 +275,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -275,6 +288,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -288,6 +302,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -304,6 +319,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -316,6 +332,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -326,6 +343,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -339,6 +357,7 @@ class DocumentDetailsResponseGrandTotal implements ModelInterface, ArrayAccess, 
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentDetailsResponseLinkedObjects.php
+++ b/src/Model/DocumentDetailsResponseLinkedObjects.php
@@ -82,6 +82,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -92,6 +93,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -140,6 +142,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -150,6 +153,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -160,6 +164,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -170,6 +175,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -202,6 +208,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -215,6 +222,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -226,6 +234,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getProvider()
     {
         return $this->container['provider'];
@@ -238,6 +247,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setProvider($provider)
     {
         $this->container['provider'] = $provider;
@@ -250,6 +260,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getEntityType()
     {
         return $this->container['entityType'];
@@ -262,6 +273,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setEntityType($entityType)
     {
         $this->container['entityType'] = $entityType;
@@ -274,6 +286,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getEntityId()
     {
         return $this->container['entityId'];
@@ -286,6 +299,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setEntityId($entityId)
     {
         $this->container['entityId'] = $entityId;
@@ -298,6 +312,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -310,6 +325,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -323,6 +339,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -335,6 +352,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -348,6 +366,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -364,6 +383,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -376,6 +396,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -386,6 +407,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -399,6 +421,7 @@ class DocumentDetailsResponseLinkedObjects implements ModelInterface, ArrayAcces
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentDetailsResponseRecipients.php
+++ b/src/Model/DocumentDetailsResponseRecipients.php
@@ -96,6 +96,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -106,6 +107,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -175,6 +177,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -185,6 +188,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -195,6 +199,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -205,6 +210,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -244,6 +250,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -257,6 +264,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -268,6 +276,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getRecipientType()
     {
         return $this->container['recipientType'];
@@ -280,6 +289,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setRecipientType($recipientType)
     {
         $this->container['recipientType'] = $recipientType;
@@ -293,6 +303,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      * @return string|null
      * @deprecated
      */
+    #[\ReturnTypeWillChange]
     public function getRole()
     {
         return $this->container['role'];
@@ -306,6 +317,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      * @return self
      * @deprecated
      */
+    #[\ReturnTypeWillChange]
     public function setRole($role)
     {
         $this->container['role'] = $role;
@@ -318,6 +330,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return string[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getRoles()
     {
         return $this->container['roles'];
@@ -330,6 +343,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setRoles($roles)
     {
         $this->container['roles'] = $roles;
@@ -342,6 +356,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getLastName()
     {
         return $this->container['lastName'];
@@ -354,6 +369,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setLastName($lastName)
     {
         $this->container['lastName'] = $lastName;
@@ -366,6 +382,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function getSigningOrder()
     {
         return $this->container['signingOrder'];
@@ -378,6 +395,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setSigningOrder($signingOrder)
     {
         $this->container['signingOrder'] = $signingOrder;
@@ -390,6 +408,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -402,6 +421,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -414,6 +434,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getContactId()
     {
         return $this->container['contactId'];
@@ -426,6 +447,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setContactId($contactId)
     {
         $this->container['contactId'] = $contactId;
@@ -438,6 +460,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getFirstName()
     {
         return $this->container['firstName'];
@@ -450,6 +473,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setFirstName($firstName)
     {
         $this->container['firstName'] = $firstName;
@@ -462,6 +486,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getEmail()
     {
         return $this->container['email'];
@@ -474,6 +499,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setEmail($email)
     {
         $this->container['email'] = $email;
@@ -486,6 +512,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getHasCompleted()
     {
         return $this->container['hasCompleted'];
@@ -498,6 +525,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setHasCompleted($hasCompleted)
     {
         $this->container['hasCompleted'] = $hasCompleted;
@@ -510,6 +538,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getSharedLink()
     {
         return $this->container['sharedLink'];
@@ -522,6 +551,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setSharedLink($sharedLink)
     {
         $this->container['sharedLink'] = $sharedLink;
@@ -535,6 +565,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -547,6 +578,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -560,6 +592,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -576,6 +609,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -588,6 +622,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -598,6 +633,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -611,6 +647,7 @@ class DocumentDetailsResponseRecipients implements ModelInterface, ArrayAccess, 
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentDetailsResponseTemplate.php
+++ b/src/Model/DocumentDetailsResponseTemplate.php
@@ -78,6 +78,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -88,6 +89,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -130,6 +132,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -140,6 +143,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -150,6 +154,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -160,6 +165,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -190,6 +196,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -203,6 +210,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -214,6 +222,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -226,6 +235,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -238,6 +248,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -250,6 +261,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -263,6 +275,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -275,6 +288,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -288,6 +302,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -304,6 +319,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -316,6 +332,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -326,6 +343,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -339,6 +357,7 @@ class DocumentDetailsResponseTemplate implements ModelInterface, ArrayAccess, \J
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentListResponse.php
+++ b/src/Model/DocumentListResponse.php
@@ -76,6 +76,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -86,6 +87,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -125,6 +127,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -135,6 +138,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -145,6 +149,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -155,6 +160,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -184,6 +190,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -197,6 +204,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -208,6 +216,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return \PandaDoc\Client\Model\DocumentListResponseResults[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getResults()
     {
         return $this->container['results'];
@@ -220,6 +229,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setResults($results)
     {
         $this->container['results'] = $results;
@@ -233,6 +243,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +256,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +270,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +287,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +300,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -296,6 +311,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -309,6 +325,7 @@ class DocumentListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentListResponseResults.php
+++ b/src/Model/DocumentListResponseResults.php
@@ -88,6 +88,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -98,6 +99,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -155,6 +157,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -165,6 +168,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -175,6 +179,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -185,6 +190,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -220,6 +226,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -233,6 +240,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -244,6 +252,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -256,6 +265,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -268,6 +278,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -280,6 +291,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -292,6 +304,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getStatus()
     {
         return $this->container['status'];
@@ -304,6 +317,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setStatus($status)
     {
         $this->container['status'] = $status;
@@ -316,6 +330,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateCreated()
     {
         return $this->container['dateCreated'];
@@ -328,6 +343,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateCreated($dateCreated)
     {
         $this->container['dateCreated'] = $dateCreated;
@@ -340,6 +356,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateModified()
     {
         return $this->container['dateModified'];
@@ -352,6 +369,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateModified($dateModified)
     {
         $this->container['dateModified'] = $dateModified;
@@ -364,6 +382,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getExpirationDate()
     {
         return $this->container['expirationDate'];
@@ -376,6 +395,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setExpirationDate($expirationDate)
     {
         $this->container['expirationDate'] = $expirationDate;
@@ -388,6 +408,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getVersion()
     {
         return $this->container['version'];
@@ -400,6 +421,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setVersion($version)
     {
         $this->container['version'] = $version;
@@ -413,6 +435,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -425,6 +448,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -438,6 +462,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -454,6 +479,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -466,6 +492,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -476,6 +503,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -489,6 +517,7 @@ class DocumentListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentOrderingFieldsEnum.php
+++ b/src/Model/DocumentOrderingFieldsEnum.php
@@ -84,6 +84,7 @@ class DocumentOrderingFieldsEnum
      * Gets allowable values of the enum
      * @return string[]
      */
+    #[\ReturnTypeWillChange]
     public static function getAllowableEnumValues()
     {
         return [

--- a/src/Model/DocumentSendRequest.php
+++ b/src/Model/DocumentSendRequest.php
@@ -82,6 +82,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -92,6 +93,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -140,6 +142,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -150,6 +153,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -160,6 +164,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -170,6 +175,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -202,6 +208,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -215,6 +222,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -226,6 +234,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getMessage()
     {
         return $this->container['message'];
@@ -238,6 +247,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setMessage($message)
     {
         $this->container['message'] = $message;
@@ -250,6 +260,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getSubject()
     {
         return $this->container['subject'];
@@ -262,6 +273,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setSubject($subject)
     {
         $this->container['subject'] = $subject;
@@ -274,6 +286,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getSilent()
     {
         return $this->container['silent'];
@@ -286,6 +299,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setSilent($silent)
     {
         $this->container['silent'] = $silent;
@@ -298,6 +312,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return array<string,string>|null
      */
+    #[\ReturnTypeWillChange]
     public function getSender()
     {
         return $this->container['sender'];
@@ -310,6 +325,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setSender($sender)
     {
         $this->container['sender'] = $sender;
@@ -323,6 +339,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -335,6 +352,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -348,6 +366,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -364,6 +383,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -376,6 +396,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -386,6 +407,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -399,6 +421,7 @@ class DocumentSendRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentSendResponse.php
+++ b/src/Model/DocumentSendResponse.php
@@ -92,6 +92,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -102,6 +103,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -165,6 +167,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -175,6 +178,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -185,6 +189,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -195,6 +200,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -232,6 +238,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -245,6 +252,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -256,6 +264,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -268,6 +277,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -280,6 +290,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -292,6 +303,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -304,6 +316,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getStatus()
     {
         return $this->container['status'];
@@ -316,6 +329,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setStatus($status)
     {
         $this->container['status'] = $status;
@@ -328,6 +342,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateCreated()
     {
         return $this->container['dateCreated'];
@@ -340,6 +355,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateCreated($dateCreated)
     {
         $this->container['dateCreated'] = $dateCreated;
@@ -352,6 +368,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateModified()
     {
         return $this->container['dateModified'];
@@ -364,6 +381,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateModified($dateModified)
     {
         $this->container['dateModified'] = $dateModified;
@@ -376,6 +394,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getExpirationDate()
     {
         return $this->container['expirationDate'];
@@ -388,6 +407,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setExpirationDate($expirationDate)
     {
         $this->container['expirationDate'] = $expirationDate;
@@ -400,6 +420,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getVersion()
     {
         return $this->container['version'];
@@ -412,6 +433,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setVersion($version)
     {
         $this->container['version'] = $version;
@@ -424,6 +446,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getUuid()
     {
         return $this->container['uuid'];
@@ -436,6 +459,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUuid($uuid)
     {
         $this->container['uuid'] = $uuid;
@@ -448,6 +472,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getSharedLink()
     {
         return $this->container['sharedLink'];
@@ -460,6 +485,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setSharedLink($sharedLink)
     {
         $this->container['sharedLink'] = $sharedLink;
@@ -473,6 +499,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -485,6 +512,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -498,6 +526,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -514,6 +543,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -526,6 +556,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -536,6 +567,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -549,6 +581,7 @@ class DocumentSendResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentStatusChangeRequest.php
+++ b/src/Model/DocumentStatusChangeRequest.php
@@ -80,6 +80,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -90,6 +91,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -135,6 +137,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -145,6 +148,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -155,6 +159,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -165,6 +170,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -196,6 +202,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -212,6 +219,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -223,6 +231,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return \PandaDoc\Client\Model\DocumentStatusRequestEnum
      */
+    #[\ReturnTypeWillChange]
     public function getStatus()
     {
         return $this->container['status'];
@@ -235,6 +244,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setStatus($status)
     {
         $this->container['status'] = $status;
@@ -247,6 +257,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getNote()
     {
         return $this->container['note'];
@@ -259,6 +270,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setNote($note)
     {
         $this->container['note'] = $note;
@@ -271,6 +283,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getNotifyRecipients()
     {
         return $this->container['notifyRecipients'];
@@ -283,6 +296,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setNotifyRecipients($notifyRecipients)
     {
         $this->container['notifyRecipients'] = $notifyRecipients;
@@ -296,6 +310,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -308,6 +323,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -321,6 +337,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -337,6 +354,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -349,6 +367,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -359,6 +378,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -372,6 +392,7 @@ class DocumentStatusChangeRequest implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentStatusEnum.php
+++ b/src/Model/DocumentStatusEnum.php
@@ -72,6 +72,7 @@ class DocumentStatusEnum
      * Gets allowable values of the enum
      * @return string[]
      */
+    #[\ReturnTypeWillChange]
     public static function getAllowableEnumValues()
     {
         return [

--- a/src/Model/DocumentStatusRequestEnum.php
+++ b/src/Model/DocumentStatusRequestEnum.php
@@ -72,6 +72,7 @@ class DocumentStatusRequestEnum
      * Gets allowable values of the enum
      * @return string[]
      */
+    #[\ReturnTypeWillChange]
     public static function getAllowableEnumValues()
     {
         return [

--- a/src/Model/DocumentStatusResponse.php
+++ b/src/Model/DocumentStatusResponse.php
@@ -92,6 +92,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -102,6 +103,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -165,6 +167,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -175,6 +178,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -185,6 +189,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -195,6 +200,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -232,6 +238,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -245,6 +252,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -256,6 +264,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -268,6 +277,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -280,6 +290,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -292,6 +303,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -304,6 +316,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getStatus()
     {
         return $this->container['status'];
@@ -316,6 +329,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setStatus($status)
     {
         $this->container['status'] = $status;
@@ -328,6 +342,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateCreated()
     {
         return $this->container['dateCreated'];
@@ -340,6 +355,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateCreated($dateCreated)
     {
         $this->container['dateCreated'] = $dateCreated;
@@ -352,6 +368,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateModified()
     {
         return $this->container['dateModified'];
@@ -364,6 +381,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateModified($dateModified)
     {
         $this->container['dateModified'] = $dateModified;
@@ -376,6 +394,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateCompleted()
     {
         return $this->container['dateCompleted'];
@@ -388,6 +407,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateCompleted($dateCompleted)
     {
         $this->container['dateCompleted'] = $dateCompleted;
@@ -400,6 +420,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getExpirationDate()
     {
         return $this->container['expirationDate'];
@@ -412,6 +433,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setExpirationDate($expirationDate)
     {
         $this->container['expirationDate'] = $expirationDate;
@@ -424,6 +446,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getVersion()
     {
         return $this->container['version'];
@@ -436,6 +459,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setVersion($version)
     {
         $this->container['version'] = $version;
@@ -448,6 +472,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getUuid()
     {
         return $this->container['uuid'];
@@ -460,6 +485,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUuid($uuid)
     {
         $this->container['uuid'] = $uuid;
@@ -473,6 +499,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -485,6 +512,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -498,6 +526,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -514,6 +543,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -526,6 +556,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -536,6 +567,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -549,6 +581,7 @@ class DocumentStatusResponse implements ModelInterface, ArrayAccess, \JsonSerial
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentTransferAllOwnershipRequest.php
+++ b/src/Model/DocumentTransferAllOwnershipRequest.php
@@ -78,6 +78,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -88,6 +89,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -130,6 +132,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -140,6 +143,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -150,6 +154,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -160,6 +165,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -190,6 +196,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -203,6 +210,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -214,6 +222,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getFromMembershipId()
     {
         return $this->container['fromMembershipId'];
@@ -226,6 +235,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setFromMembershipId($fromMembershipId)
     {
         $this->container['fromMembershipId'] = $fromMembershipId;
@@ -238,6 +248,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getToMembershipId()
     {
         return $this->container['toMembershipId'];
@@ -250,6 +261,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setToMembershipId($toMembershipId)
     {
         $this->container['toMembershipId'] = $toMembershipId;
@@ -263,6 +275,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -275,6 +288,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -288,6 +302,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -304,6 +319,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -316,6 +332,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -326,6 +343,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -339,6 +357,7 @@ class DocumentTransferAllOwnershipRequest implements ModelInterface, ArrayAccess
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentTransferOwnershipRequest.php
+++ b/src/Model/DocumentTransferOwnershipRequest.php
@@ -76,6 +76,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -86,6 +87,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -125,6 +127,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -135,6 +138,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -145,6 +149,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -155,6 +160,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -184,6 +190,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -197,6 +204,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -208,6 +216,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getMembershipId()
     {
         return $this->container['membershipId'];
@@ -220,6 +229,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setMembershipId($membershipId)
     {
         $this->container['membershipId'] = $membershipId;
@@ -233,6 +243,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +256,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +270,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +287,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +300,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -296,6 +311,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -309,6 +325,7 @@ class DocumentTransferOwnershipRequest implements ModelInterface, ArrayAccess, \
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentUpdateRequest.php
+++ b/src/Model/DocumentUpdateRequest.php
@@ -84,6 +84,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -94,6 +95,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -145,6 +147,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -155,6 +158,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -165,6 +169,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -175,6 +180,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -208,6 +214,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -221,6 +228,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -232,6 +240,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return \PandaDoc\Client\Model\DocumentUpdateRequestRecipients[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getRecipients()
     {
         return $this->container['recipients'];
@@ -244,6 +253,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setRecipients($recipients)
     {
         $this->container['recipients'] = $recipients;
@@ -256,6 +266,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getFields()
     {
         return $this->container['fields'];
@@ -268,6 +279,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setFields($fields)
     {
         $this->container['fields'] = $fields;
@@ -280,6 +292,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return \PandaDoc\Client\Model\DocumentCreateByTemplateRequestTokens[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getTokens()
     {
         return $this->container['tokens'];
@@ -292,6 +305,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTokens($tokens)
     {
         $this->container['tokens'] = $tokens;
@@ -304,6 +318,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getMetadata()
     {
         return $this->container['metadata'];
@@ -316,6 +331,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setMetadata($metadata)
     {
         $this->container['metadata'] = $metadata;
@@ -328,6 +344,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return \PandaDoc\Client\Model\PricingTableRequest[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getPricingTables()
     {
         return $this->container['pricingTables'];
@@ -340,6 +357,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setPricingTables($pricingTables)
     {
         $this->container['pricingTables'] = $pricingTables;
@@ -353,6 +371,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -365,6 +384,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -378,6 +398,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -394,6 +415,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -406,6 +428,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -416,6 +439,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -429,6 +453,7 @@ class DocumentUpdateRequest implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentUpdateRequestRecipients.php
+++ b/src/Model/DocumentUpdateRequestRecipients.php
@@ -82,6 +82,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -92,6 +93,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -140,6 +142,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -150,6 +153,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -160,6 +164,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -170,6 +175,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -202,6 +208,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -215,6 +222,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -226,6 +234,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -238,6 +247,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -250,6 +260,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getEmail()
     {
         return $this->container['email'];
@@ -262,6 +273,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setEmail($email)
     {
         $this->container['email'] = $email;
@@ -274,6 +286,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getFirstName()
     {
         return $this->container['firstName'];
@@ -286,6 +299,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setFirstName($firstName)
     {
         $this->container['firstName'] = $firstName;
@@ -298,6 +312,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getLastName()
     {
         return $this->container['lastName'];
@@ -310,6 +325,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setLastName($lastName)
     {
         $this->container['lastName'] = $lastName;
@@ -323,6 +339,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -335,6 +352,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -348,6 +366,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -364,6 +383,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -376,6 +396,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -386,6 +407,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -399,6 +421,7 @@ class DocumentUpdateRequestRecipients implements ModelInterface, ArrayAccess, \J
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentsFolderCreateRequest.php
+++ b/src/Model/DocumentsFolderCreateRequest.php
@@ -78,6 +78,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -88,6 +89,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -130,6 +132,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -140,6 +143,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -150,6 +154,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -160,6 +165,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -190,6 +196,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -206,6 +213,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -217,6 +225,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -229,6 +238,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -241,6 +251,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getParentUuid()
     {
         return $this->container['parentUuid'];
@@ -253,6 +264,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setParentUuid($parentUuid)
     {
         $this->container['parentUuid'] = $parentUuid;
@@ -266,6 +278,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -278,6 +291,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -291,6 +305,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -307,6 +322,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -319,6 +335,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -329,6 +346,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -342,6 +360,7 @@ class DocumentsFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentsFolderCreateResponse.php
+++ b/src/Model/DocumentsFolderCreateResponse.php
@@ -80,6 +80,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -90,6 +91,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -135,6 +137,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -145,6 +148,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -155,6 +159,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -165,6 +170,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -196,6 +202,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -209,6 +216,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -220,6 +228,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getUuid()
     {
         return $this->container['uuid'];
@@ -232,6 +241,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUuid($uuid)
     {
         $this->container['uuid'] = $uuid;
@@ -244,6 +254,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -256,6 +267,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -268,6 +280,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateCreated()
     {
         return $this->container['dateCreated'];
@@ -280,6 +293,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateCreated($dateCreated)
     {
         $this->container['dateCreated'] = $dateCreated;
@@ -293,6 +307,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -305,6 +320,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -318,6 +334,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -334,6 +351,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -346,6 +364,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -356,6 +375,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -369,6 +389,7 @@ class DocumentsFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentsFolderListResponse.php
+++ b/src/Model/DocumentsFolderListResponse.php
@@ -76,6 +76,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -86,6 +87,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -125,6 +127,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -135,6 +138,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -145,6 +149,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -155,6 +160,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -184,6 +190,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -197,6 +204,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -208,6 +216,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return \PandaDoc\Client\Model\DocumentsFolderListResponseResults[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getResults()
     {
         return $this->container['results'];
@@ -220,6 +229,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setResults($results)
     {
         $this->container['results'] = $results;
@@ -233,6 +243,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +256,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +270,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +287,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +300,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -296,6 +311,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -309,6 +325,7 @@ class DocumentsFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentsFolderListResponseResults.php
+++ b/src/Model/DocumentsFolderListResponseResults.php
@@ -84,6 +84,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -94,6 +95,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -145,6 +147,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -155,6 +158,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -165,6 +169,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -175,6 +180,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -208,6 +214,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -221,6 +228,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -232,6 +240,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getUuid()
     {
         return $this->container['uuid'];
@@ -244,6 +253,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUuid($uuid)
     {
         $this->container['uuid'] = $uuid;
@@ -256,6 +266,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -268,6 +279,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -280,6 +292,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateCreated()
     {
         return $this->container['dateCreated'];
@@ -292,6 +305,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateCreated($dateCreated)
     {
         $this->container['dateCreated'] = $dateCreated;
@@ -304,6 +318,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getHasFolders()
     {
         return $this->container['hasFolders'];
@@ -316,6 +331,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setHasFolders($hasFolders)
     {
         $this->container['hasFolders'] = $hasFolders;
@@ -328,6 +344,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getHasItems()
     {
         return $this->container['hasItems'];
@@ -340,6 +357,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setHasItems($hasItems)
     {
         $this->container['hasItems'] = $hasItems;
@@ -353,6 +371,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -365,6 +384,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -378,6 +398,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -394,6 +415,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -406,6 +428,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -416,6 +439,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -429,6 +453,7 @@ class DocumentsFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentsFolderRenameRequest.php
+++ b/src/Model/DocumentsFolderRenameRequest.php
@@ -76,6 +76,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -86,6 +87,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -125,6 +127,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -135,6 +138,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -145,6 +149,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -155,6 +160,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -184,6 +190,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -200,6 +207,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -211,6 +219,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -223,6 +232,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -236,6 +246,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -248,6 +259,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -261,6 +273,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -277,6 +290,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -289,6 +303,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -299,6 +314,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -312,6 +328,7 @@ class DocumentsFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/DocumentsFolderRenameResponse.php
+++ b/src/Model/DocumentsFolderRenameResponse.php
@@ -80,6 +80,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -90,6 +91,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -135,6 +137,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -145,6 +148,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -155,6 +159,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -165,6 +170,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -196,6 +202,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -209,6 +216,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -220,6 +228,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getUuid()
     {
         return $this->container['uuid'];
@@ -232,6 +241,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUuid($uuid)
     {
         $this->container['uuid'] = $uuid;
@@ -244,6 +254,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -256,6 +267,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -268,6 +280,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateCreated()
     {
         return $this->container['dateCreated'];
@@ -280,6 +293,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateCreated($dateCreated)
     {
         $this->container['dateCreated'] = $dateCreated;
@@ -293,6 +307,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -305,6 +320,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -318,6 +334,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -334,6 +351,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -346,6 +364,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -356,6 +375,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -369,6 +389,7 @@ class DocumentsFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/FormListResponse.php
+++ b/src/Model/FormListResponse.php
@@ -78,6 +78,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -88,6 +89,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -130,6 +132,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -140,6 +143,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -150,6 +154,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -160,6 +165,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -190,6 +196,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -203,6 +210,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -214,6 +222,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return \PandaDoc\Client\Model\FormListResponseResults[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getResults()
     {
         return $this->container['results'];
@@ -226,6 +235,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setResults($results)
     {
         $this->container['results'] = $results;
@@ -238,6 +248,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getHasNextPage()
     {
         return $this->container['hasNextPage'];
@@ -250,6 +261,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setHasNextPage($hasNextPage)
     {
         $this->container['hasNextPage'] = $hasNextPage;
@@ -263,6 +275,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -275,6 +288,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -288,6 +302,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -304,6 +319,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -316,6 +332,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -326,6 +343,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -339,6 +357,7 @@ class FormListResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/FormListResponseResults.php
+++ b/src/Model/FormListResponseResults.php
@@ -84,6 +84,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -94,6 +95,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -145,6 +147,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -155,6 +158,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -165,6 +169,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -175,6 +180,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -208,6 +214,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -221,6 +228,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -232,6 +240,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -244,6 +253,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -256,6 +266,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -268,6 +279,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -280,6 +292,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateCreated()
     {
         return $this->container['dateCreated'];
@@ -292,6 +305,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateCreated($dateCreated)
     {
         $this->container['dateCreated'] = $dateCreated;
@@ -304,6 +318,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateModified()
     {
         return $this->container['dateModified'];
@@ -316,6 +331,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateModified($dateModified)
     {
         $this->container['dateModified'] = $dateModified;
@@ -328,6 +344,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getStatus()
     {
         return $this->container['status'];
@@ -340,6 +357,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setStatus($status)
     {
         $this->container['status'] = $status;
@@ -353,6 +371,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -365,6 +384,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -378,6 +398,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -394,6 +415,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -406,6 +428,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -416,6 +439,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -429,6 +453,7 @@ class FormListResponseResults implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/LinkedObjectCreateRequest.php
+++ b/src/Model/LinkedObjectCreateRequest.php
@@ -80,6 +80,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -90,6 +91,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -135,6 +137,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -145,6 +148,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -155,6 +159,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -165,6 +170,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -196,6 +202,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -218,6 +225,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -229,6 +237,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getProvider()
     {
         return $this->container['provider'];
@@ -241,6 +250,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setProvider($provider)
     {
         $this->container['provider'] = $provider;
@@ -253,6 +263,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getEntityType()
     {
         return $this->container['entityType'];
@@ -265,6 +276,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setEntityType($entityType)
     {
         $this->container['entityType'] = $entityType;
@@ -277,6 +289,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getEntityId()
     {
         return $this->container['entityId'];
@@ -289,6 +302,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setEntityId($entityId)
     {
         $this->container['entityId'] = $entityId;
@@ -302,6 +316,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -314,6 +329,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -327,6 +343,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -343,6 +360,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -355,6 +373,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -365,6 +384,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -378,6 +398,7 @@ class LinkedObjectCreateRequest implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/LinkedObjectCreateResponse.php
+++ b/src/Model/LinkedObjectCreateResponse.php
@@ -82,6 +82,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -92,6 +93,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -140,6 +142,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -150,6 +153,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -160,6 +164,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -170,6 +175,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -202,6 +208,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -215,6 +222,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -226,6 +234,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -238,6 +247,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -250,6 +260,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getProvider()
     {
         return $this->container['provider'];
@@ -262,6 +273,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setProvider($provider)
     {
         $this->container['provider'] = $provider;
@@ -274,6 +286,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getEntityType()
     {
         return $this->container['entityType'];
@@ -286,6 +299,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setEntityType($entityType)
     {
         $this->container['entityType'] = $entityType;
@@ -298,6 +312,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getEntiryId()
     {
         return $this->container['entiryId'];
@@ -310,6 +325,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setEntiryId($entiryId)
     {
         $this->container['entiryId'] = $entiryId;
@@ -323,6 +339,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -335,6 +352,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -348,6 +366,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -364,6 +383,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -376,6 +396,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -386,6 +407,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -399,6 +421,7 @@ class LinkedObjectCreateResponse implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/LinkedObjectListResponse.php
+++ b/src/Model/LinkedObjectListResponse.php
@@ -76,6 +76,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -86,6 +87,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -125,6 +127,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -135,6 +138,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -145,6 +149,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -155,6 +160,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -184,6 +190,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -197,6 +204,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -208,6 +216,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return \PandaDoc\Client\Model\LinkedObjectCreateResponse[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getLinkedObjects()
     {
         return $this->container['linkedObjects'];
@@ -220,6 +229,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setLinkedObjects($linkedObjects)
     {
         $this->container['linkedObjects'] = $linkedObjects;
@@ -233,6 +243,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +256,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +270,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +287,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +300,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -296,6 +311,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -309,6 +325,7 @@ class LinkedObjectListResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/MemberDetailsResponse.php
+++ b/src/Model/MemberDetailsResponse.php
@@ -100,6 +100,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -110,6 +111,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -185,6 +187,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -195,6 +198,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -205,6 +209,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -215,6 +220,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -256,6 +262,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -269,6 +276,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -280,6 +288,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getUserId()
     {
         return $this->container['userId'];
@@ -292,6 +301,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUserId($userId)
     {
         $this->container['userId'] = $userId;
@@ -304,6 +314,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getMembershipId()
     {
         return $this->container['membershipId'];
@@ -316,6 +327,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setMembershipId($membershipId)
     {
         $this->container['membershipId'] = $membershipId;
@@ -328,6 +340,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getEmail()
     {
         return $this->container['email'];
@@ -340,6 +353,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setEmail($email)
     {
         $this->container['email'] = $email;
@@ -352,6 +366,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getFirstName()
     {
         return $this->container['firstName'];
@@ -364,6 +379,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setFirstName($firstName)
     {
         $this->container['firstName'] = $firstName;
@@ -376,6 +392,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getLastName()
     {
         return $this->container['lastName'];
@@ -388,6 +405,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setLastName($lastName)
     {
         $this->container['lastName'] = $lastName;
@@ -400,6 +418,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getIsActive()
     {
         return $this->container['isActive'];
@@ -412,6 +431,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setIsActive($isActive)
     {
         $this->container['isActive'] = $isActive;
@@ -424,6 +444,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getWorkspace()
     {
         return $this->container['workspace'];
@@ -436,6 +457,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setWorkspace($workspace)
     {
         $this->container['workspace'] = $workspace;
@@ -448,6 +470,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getWorkspaceName()
     {
         return $this->container['workspaceName'];
@@ -460,6 +483,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setWorkspaceName($workspaceName)
     {
         $this->container['workspaceName'] = $workspaceName;
@@ -472,6 +496,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getEmailsVerified()
     {
         return $this->container['emailsVerified'];
@@ -484,6 +509,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setEmailsVerified($emailsVerified)
     {
         $this->container['emailsVerified'] = $emailsVerified;
@@ -496,6 +522,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getRole()
     {
         return $this->container['role'];
@@ -508,6 +535,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setRole($role)
     {
         $this->container['role'] = $role;
@@ -520,6 +548,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getUserLicense()
     {
         return $this->container['userLicense'];
@@ -532,6 +561,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUserLicense($userLicense)
     {
         $this->container['userLicense'] = $userLicense;
@@ -544,6 +574,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateCreated()
     {
         return $this->container['dateCreated'];
@@ -556,6 +587,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateCreated($dateCreated)
     {
         $this->container['dateCreated'] = $dateCreated;
@@ -568,6 +600,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateModified()
     {
         return $this->container['dateModified'];
@@ -580,6 +613,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateModified($dateModified)
     {
         $this->container['dateModified'] = $dateModified;
@@ -593,6 +627,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -605,6 +640,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -618,6 +654,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -634,6 +671,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -646,6 +684,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -656,6 +695,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -669,6 +709,7 @@ class MemberDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/MemberListResponse.php
+++ b/src/Model/MemberListResponse.php
@@ -76,6 +76,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -86,6 +87,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -125,6 +127,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -135,6 +138,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -145,6 +149,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -155,6 +160,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -184,6 +190,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -197,6 +204,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -208,6 +216,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return \PandaDoc\Client\Model\MemberDetailsResponse[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getResults()
     {
         return $this->container['results'];
@@ -220,6 +229,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setResults($results)
     {
         $this->container['results'] = $results;
@@ -233,6 +243,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +256,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +270,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +287,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +300,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -296,6 +311,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -309,6 +325,7 @@ class MemberListResponse implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/OAuth2AccessTokenResponse.php
+++ b/src/Model/OAuth2AccessTokenResponse.php
@@ -84,6 +84,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -94,6 +95,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -145,6 +147,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -155,6 +158,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -165,6 +169,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -175,6 +180,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -208,6 +214,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -221,6 +228,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -232,6 +240,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getAccessToken()
     {
         return $this->container['accessToken'];
@@ -244,6 +253,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setAccessToken($accessToken)
     {
         $this->container['accessToken'] = $accessToken;
@@ -256,6 +266,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getTokenType()
     {
         return $this->container['tokenType'];
@@ -268,6 +279,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTokenType($tokenType)
     {
         $this->container['tokenType'] = $tokenType;
@@ -280,6 +292,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return float|null
      */
+    #[\ReturnTypeWillChange]
     public function getExpiresIn()
     {
         return $this->container['expiresIn'];
@@ -292,6 +305,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setExpiresIn($expiresIn)
     {
         $this->container['expiresIn'] = $expiresIn;
@@ -304,6 +318,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getScope()
     {
         return $this->container['scope'];
@@ -316,6 +331,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setScope($scope)
     {
         $this->container['scope'] = $scope;
@@ -328,6 +344,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getRefreshToken()
     {
         return $this->container['refreshToken'];
@@ -340,6 +357,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setRefreshToken($refreshToken)
     {
         $this->container['refreshToken'] = $refreshToken;
@@ -353,6 +371,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -365,6 +384,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -378,6 +398,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -394,6 +415,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -406,6 +428,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -416,6 +439,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -429,6 +453,7 @@ class OAuth2AccessTokenResponse implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/PricingTableRequest.php
+++ b/src/Model/PricingTableRequest.php
@@ -82,6 +82,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -92,6 +93,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -140,6 +142,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -150,6 +153,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -160,6 +164,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -170,6 +175,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -202,6 +208,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -218,6 +225,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -229,6 +237,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -241,6 +250,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -253,6 +263,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getDataMerge()
     {
         return $this->container['dataMerge'];
@@ -265,6 +276,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDataMerge($dataMerge)
     {
         $this->container['dataMerge'] = $dataMerge;
@@ -277,6 +289,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getOptions()
     {
         return $this->container['options'];
@@ -289,6 +302,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setOptions($options)
     {
         $this->container['options'] = $options;
@@ -301,6 +315,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return \PandaDoc\Client\Model\PricingTableRequestSections[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getSections()
     {
         return $this->container['sections'];
@@ -313,6 +328,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setSections($sections)
     {
         $this->container['sections'] = $sections;
@@ -326,6 +342,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -338,6 +355,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -351,6 +369,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -367,6 +386,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -379,6 +399,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -389,6 +410,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -402,6 +424,7 @@ class PricingTableRequest implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/PricingTableRequestRowOptions.php
+++ b/src/Model/PricingTableRequestRowOptions.php
@@ -80,6 +80,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -90,6 +91,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -135,6 +137,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -145,6 +148,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -155,6 +159,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -165,6 +170,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -196,6 +202,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -209,6 +216,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -220,6 +228,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getQtyEditable()
     {
         return $this->container['qtyEditable'];
@@ -232,6 +241,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setQtyEditable($qtyEditable)
     {
         $this->container['qtyEditable'] = $qtyEditable;
@@ -244,6 +254,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getOptionalSelected()
     {
         return $this->container['optionalSelected'];
@@ -256,6 +267,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setOptionalSelected($optionalSelected)
     {
         $this->container['optionalSelected'] = $optionalSelected;
@@ -268,6 +280,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getOptional()
     {
         return $this->container['optional'];
@@ -280,6 +293,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setOptional($optional)
     {
         $this->container['optional'] = $optional;
@@ -293,6 +307,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -305,6 +320,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -318,6 +334,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -334,6 +351,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -346,6 +364,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -356,6 +375,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -369,6 +389,7 @@ class PricingTableRequestRowOptions implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/PricingTableRequestRows.php
+++ b/src/Model/PricingTableRequestRows.php
@@ -80,6 +80,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -90,6 +91,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -135,6 +137,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -145,6 +148,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -155,6 +159,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -165,6 +170,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -196,6 +202,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -209,6 +216,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -220,6 +228,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return \PandaDoc\Client\Model\PricingTableRequestRowOptions|null
      */
+    #[\ReturnTypeWillChange]
     public function getOptions()
     {
         return $this->container['options'];
@@ -232,6 +241,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setOptions($options)
     {
         $this->container['options'] = $options;
@@ -244,6 +254,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getData()
     {
         return $this->container['data'];
@@ -256,6 +267,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setData($data)
     {
         $this->container['data'] = $data;
@@ -268,6 +280,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getCustomFields()
     {
         return $this->container['customFields'];
@@ -280,6 +293,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setCustomFields($customFields)
     {
         $this->container['customFields'] = $customFields;
@@ -293,6 +307,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -305,6 +320,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -318,6 +334,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -334,6 +351,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -346,6 +364,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -356,6 +375,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -369,6 +389,7 @@ class PricingTableRequestRows implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/PricingTableRequestSections.php
+++ b/src/Model/PricingTableRequestSections.php
@@ -82,6 +82,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -92,6 +93,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -140,6 +142,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -150,6 +153,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -160,6 +164,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -170,6 +175,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -202,6 +208,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -218,6 +225,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -229,6 +237,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getTitle()
     {
         return $this->container['title'];
@@ -241,6 +250,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTitle($title)
     {
         $this->container['title'] = $title;
@@ -253,6 +263,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getDefault()
     {
         return $this->container['default'];
@@ -265,6 +276,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDefault($default)
     {
         $this->container['default'] = $default;
@@ -277,6 +289,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getMultichoiceEnabled()
     {
         return $this->container['multichoiceEnabled'];
@@ -289,6 +302,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setMultichoiceEnabled($multichoiceEnabled)
     {
         $this->container['multichoiceEnabled'] = $multichoiceEnabled;
@@ -301,6 +315,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return \PandaDoc\Client\Model\PricingTableRequestRows[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getRows()
     {
         return $this->container['rows'];
@@ -313,6 +328,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setRows($rows)
     {
         $this->container['rows'] = $rows;
@@ -326,6 +342,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -338,6 +355,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -351,6 +369,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -367,6 +386,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -379,6 +399,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -389,6 +410,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -402,6 +424,7 @@ class PricingTableRequestSections implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/PricingTablesResponse.php
+++ b/src/Model/PricingTablesResponse.php
@@ -78,6 +78,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -88,6 +89,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -130,6 +132,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -140,6 +143,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -150,6 +154,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -160,6 +165,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -190,6 +196,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -203,6 +210,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -214,6 +222,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return \PandaDoc\Client\Model\PricingTablesResponseTables[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getTables()
     {
         return $this->container['tables'];
@@ -226,6 +235,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTables($tables)
     {
         $this->container['tables'] = $tables;
@@ -238,6 +248,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getTotal()
     {
         return $this->container['total'];
@@ -250,6 +261,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTotal($total)
     {
         $this->container['total'] = $total;
@@ -263,6 +275,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -275,6 +288,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -288,6 +302,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -304,6 +319,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -316,6 +332,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -326,6 +343,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -339,6 +357,7 @@ class PricingTablesResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/PricingTablesResponseDiscount.php
+++ b/src/Model/PricingTablesResponseDiscount.php
@@ -78,6 +78,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -88,6 +89,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -130,6 +132,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -140,6 +143,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -150,6 +154,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -160,6 +165,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -190,6 +196,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -203,6 +210,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -214,6 +222,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getValue()
     {
         return $this->container['value'];
@@ -226,6 +235,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setValue($value)
     {
         $this->container['value'] = $value;
@@ -238,6 +248,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getType()
     {
         return $this->container['type'];
@@ -250,6 +261,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setType($type)
     {
         $this->container['type'] = $type;
@@ -263,6 +275,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -275,6 +288,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -288,6 +302,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -304,6 +319,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -316,6 +332,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -326,6 +343,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -339,6 +357,7 @@ class PricingTablesResponseDiscount implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/PricingTablesResponseItems.php
+++ b/src/Model/PricingTablesResponseItems.php
@@ -112,6 +112,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -122,6 +123,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -215,6 +217,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -225,6 +228,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -235,6 +239,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -245,6 +250,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -292,6 +298,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -305,6 +312,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -316,6 +324,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -328,6 +337,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -340,6 +350,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getSku()
     {
         return $this->container['sku'];
@@ -352,6 +363,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setSku($sku)
     {
         $this->container['sku'] = $sku;
@@ -364,6 +376,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getQty()
     {
         return $this->container['qty'];
@@ -376,6 +389,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setQty($qty)
     {
         $this->container['qty'] = $qty;
@@ -388,6 +402,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -400,6 +415,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -412,6 +428,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getCost()
     {
         return $this->container['cost'];
@@ -424,6 +441,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setCost($cost)
     {
         $this->container['cost'] = $cost;
@@ -436,6 +454,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getPrice()
     {
         return $this->container['price'];
@@ -448,6 +467,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setPrice($price)
     {
         $this->container['price'] = $price;
@@ -460,6 +480,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDescription()
     {
         return $this->container['description'];
@@ -472,6 +493,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDescription($description)
     {
         $this->container['description'] = $description;
@@ -484,6 +506,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getCustomFields()
     {
         return $this->container['customFields'];
@@ -496,6 +519,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setCustomFields($customFields)
     {
         $this->container['customFields'] = $customFields;
@@ -508,6 +532,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getCustomColumns()
     {
         return $this->container['customColumns'];
@@ -520,6 +545,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setCustomColumns($customColumns)
     {
         $this->container['customColumns'] = $customColumns;
@@ -532,6 +558,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return \PandaDoc\Client\Model\PricingTablesResponseDiscount|null
      */
+    #[\ReturnTypeWillChange]
     public function getDiscount()
     {
         return $this->container['discount'];
@@ -544,6 +571,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDiscount($discount)
     {
         $this->container['discount'] = $discount;
@@ -556,6 +584,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return \PandaDoc\Client\Model\PricingTablesResponseDiscount|null
      */
+    #[\ReturnTypeWillChange]
     public function getTaxFirst()
     {
         return $this->container['taxFirst'];
@@ -568,6 +597,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTaxFirst($taxFirst)
     {
         $this->container['taxFirst'] = $taxFirst;
@@ -580,6 +610,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return \PandaDoc\Client\Model\PricingTablesResponseDiscount|null
      */
+    #[\ReturnTypeWillChange]
     public function getTaxSecond()
     {
         return $this->container['taxSecond'];
@@ -592,6 +623,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTaxSecond($taxSecond)
     {
         $this->container['taxSecond'] = $taxSecond;
@@ -604,6 +636,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getSubtotal()
     {
         return $this->container['subtotal'];
@@ -616,6 +649,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setSubtotal($subtotal)
     {
         $this->container['subtotal'] = $subtotal;
@@ -628,6 +662,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return \PandaDoc\Client\Model\PricingTablesResponseOptions|null
      */
+    #[\ReturnTypeWillChange]
     public function getOptions()
     {
         return $this->container['options'];
@@ -640,6 +675,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setOptions($options)
     {
         $this->container['options'] = $options;
@@ -652,6 +688,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getSalePrice()
     {
         return $this->container['salePrice'];
@@ -664,6 +701,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setSalePrice($salePrice)
     {
         $this->container['salePrice'] = $salePrice;
@@ -676,6 +714,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getTaxes()
     {
         return $this->container['taxes'];
@@ -688,6 +727,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTaxes($taxes)
     {
         $this->container['taxes'] = $taxes;
@@ -700,6 +740,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getDiscounts()
     {
         return $this->container['discounts'];
@@ -712,6 +753,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDiscounts($discounts)
     {
         $this->container['discounts'] = $discounts;
@@ -724,6 +766,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getFees()
     {
         return $this->container['fees'];
@@ -736,6 +779,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setFees($fees)
     {
         $this->container['fees'] = $fees;
@@ -748,6 +792,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getMergedData()
     {
         return $this->container['mergedData'];
@@ -760,6 +805,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setMergedData($mergedData)
     {
         $this->container['mergedData'] = $mergedData;
@@ -773,6 +819,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -785,6 +832,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -798,6 +846,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -814,6 +863,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -826,6 +876,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -836,6 +887,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -849,6 +901,7 @@ class PricingTablesResponseItems implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/PricingTablesResponseOptions.php
+++ b/src/Model/PricingTablesResponseOptions.php
@@ -82,6 +82,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -92,6 +93,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -140,6 +142,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -150,6 +153,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -160,6 +164,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -170,6 +175,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -202,6 +208,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -215,6 +222,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -226,6 +234,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getOptional()
     {
         return $this->container['optional'];
@@ -238,6 +247,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setOptional($optional)
     {
         $this->container['optional'] = $optional;
@@ -250,6 +260,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getOptionalSelected()
     {
         return $this->container['optionalSelected'];
@@ -262,6 +273,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setOptionalSelected($optionalSelected)
     {
         $this->container['optionalSelected'] = $optionalSelected;
@@ -274,6 +286,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getMultichoiceEnabled()
     {
         return $this->container['multichoiceEnabled'];
@@ -286,6 +299,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setMultichoiceEnabled($multichoiceEnabled)
     {
         $this->container['multichoiceEnabled'] = $multichoiceEnabled;
@@ -298,6 +312,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getMultichoiceSelected()
     {
         return $this->container['multichoiceSelected'];
@@ -310,6 +325,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setMultichoiceSelected($multichoiceSelected)
     {
         $this->container['multichoiceSelected'] = $multichoiceSelected;
@@ -323,6 +339,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -335,6 +352,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -348,6 +366,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -364,6 +383,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -376,6 +396,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -386,6 +407,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -399,6 +421,7 @@ class PricingTablesResponseOptions implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/PricingTablesResponseSummary.php
+++ b/src/Model/PricingTablesResponseSummary.php
@@ -82,6 +82,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -92,6 +93,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -140,6 +142,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -150,6 +153,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -160,6 +164,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -170,6 +175,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -202,6 +208,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -215,6 +222,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -226,6 +234,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getSubtotal()
     {
         return $this->container['subtotal'];
@@ -238,6 +247,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setSubtotal($subtotal)
     {
         $this->container['subtotal'] = $subtotal;
@@ -250,6 +260,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getTotal()
     {
         return $this->container['total'];
@@ -262,6 +273,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTotal($total)
     {
         $this->container['total'] = $total;
@@ -274,6 +286,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDiscount()
     {
         return $this->container['discount'];
@@ -286,6 +299,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDiscount($discount)
     {
         $this->container['discount'] = $discount;
@@ -298,6 +312,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getTax()
     {
         return $this->container['tax'];
@@ -310,6 +325,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTax($tax)
     {
         $this->container['tax'] = $tax;
@@ -323,6 +339,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -335,6 +352,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -348,6 +366,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -364,6 +383,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -376,6 +396,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -386,6 +407,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -399,6 +421,7 @@ class PricingTablesResponseSummary implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/PricingTablesResponseTables.php
+++ b/src/Model/PricingTablesResponseTables.php
@@ -88,6 +88,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -98,6 +99,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -155,6 +157,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -165,6 +168,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -175,6 +179,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -185,6 +190,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -220,6 +226,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -233,6 +240,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -244,6 +252,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -256,6 +265,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -268,6 +278,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -280,6 +291,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -292,6 +304,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getTotal()
     {
         return $this->container['total'];
@@ -304,6 +317,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTotal($total)
     {
         $this->container['total'] = $total;
@@ -316,6 +330,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getIsIncludedInTotal()
     {
         return $this->container['isIncludedInTotal'];
@@ -328,6 +343,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setIsIncludedInTotal($isIncludedInTotal)
     {
         $this->container['isIncludedInTotal'] = $isIncludedInTotal;
@@ -340,6 +356,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return \PandaDoc\Client\Model\PricingTablesResponseSummary|null
      */
+    #[\ReturnTypeWillChange]
     public function getSummary()
     {
         return $this->container['summary'];
@@ -352,6 +369,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setSummary($summary)
     {
         $this->container['summary'] = $summary;
@@ -364,6 +382,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return \PandaDoc\Client\Model\PricingTablesResponseItems[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getItems()
     {
         return $this->container['items'];
@@ -376,6 +395,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setItems($items)
     {
         $this->container['items'] = $items;
@@ -388,6 +408,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getCurrency()
     {
         return $this->container['currency'];
@@ -400,6 +421,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setCurrency($currency)
     {
         $this->container['currency'] = $currency;
@@ -413,6 +435,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -425,6 +448,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -438,6 +462,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -454,6 +479,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -466,6 +492,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -476,6 +503,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -489,6 +517,7 @@ class PricingTablesResponseTables implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/TemplateDetailsResponse.php
+++ b/src/Model/TemplateDetailsResponse.php
@@ -102,6 +102,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -112,6 +113,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -190,6 +192,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -200,6 +203,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -210,6 +214,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -220,6 +225,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -262,6 +268,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -275,6 +282,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -286,6 +294,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -298,6 +307,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -310,6 +320,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -322,6 +333,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -334,6 +346,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateCreated()
     {
         return $this->container['dateCreated'];
@@ -346,6 +359,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateCreated($dateCreated)
     {
         $this->container['dateCreated'] = $dateCreated;
@@ -358,6 +372,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateModified()
     {
         return $this->container['dateModified'];
@@ -370,6 +385,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateModified($dateModified)
     {
         $this->container['dateModified'] = $dateModified;
@@ -382,6 +398,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return \PandaDoc\Client\Model\ContentLibraryItemResponseCreatedBy|null
      */
+    #[\ReturnTypeWillChange]
     public function getCreatedBy()
     {
         return $this->container['createdBy'];
@@ -394,6 +411,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setCreatedBy($createdBy)
     {
         $this->container['createdBy'] = $createdBy;
@@ -406,6 +424,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return object|null
      */
+    #[\ReturnTypeWillChange]
     public function getMetadata()
     {
         return $this->container['metadata'];
@@ -418,6 +437,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setMetadata($metadata)
     {
         $this->container['metadata'] = $metadata;
@@ -430,6 +450,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return \PandaDoc\Client\Model\TemplateDetailsResponseTokens[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getTokens()
     {
         return $this->container['tokens'];
@@ -442,6 +463,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTokens($tokens)
     {
         $this->container['tokens'] = $tokens;
@@ -454,6 +476,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return object[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getFields()
     {
         return $this->container['fields'];
@@ -466,6 +489,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setFields($fields)
     {
         $this->container['fields'] = $fields;
@@ -478,6 +502,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return \PandaDoc\Client\Model\PricingTablesResponse|null
      */
+    #[\ReturnTypeWillChange]
     public function getPricing()
     {
         return $this->container['pricing'];
@@ -490,6 +515,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setPricing($pricing)
     {
         $this->container['pricing'] = $pricing;
@@ -502,6 +528,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getTags()
     {
         return $this->container['tags'];
@@ -514,6 +541,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTags($tags)
     {
         $this->container['tags'] = $tags;
@@ -526,6 +554,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return \PandaDoc\Client\Model\TemplateDetailsResponseRoles[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getRoles()
     {
         return $this->container['roles'];
@@ -538,6 +567,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setRoles($roles)
     {
         $this->container['roles'] = $roles;
@@ -550,6 +580,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getVersion()
     {
         return $this->container['version'];
@@ -562,6 +593,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setVersion($version)
     {
         $this->container['version'] = $version;
@@ -574,6 +606,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return \PandaDoc\Client\Model\TemplateDetailsResponseContentPlaceholders[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getContentPlaceholders()
     {
         return $this->container['contentPlaceholders'];
@@ -586,6 +619,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setContentPlaceholders($contentPlaceholders)
     {
         $this->container['contentPlaceholders'] = $contentPlaceholders;
@@ -598,6 +632,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return \PandaDoc\Client\Model\TemplateDetailsResponseImages[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getImages()
     {
         return $this->container['images'];
@@ -610,6 +645,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setImages($images)
     {
         $this->container['images'] = $images;
@@ -623,6 +659,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -635,6 +672,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -648,6 +686,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -664,6 +703,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -676,6 +716,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -686,6 +727,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -699,6 +741,7 @@ class TemplateDetailsResponse implements ModelInterface, ArrayAccess, \JsonSeria
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/TemplateDetailsResponseContentPlaceholders.php
+++ b/src/Model/TemplateDetailsResponseContentPlaceholders.php
@@ -80,6 +80,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -90,6 +91,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -135,6 +137,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -145,6 +148,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -155,6 +159,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -165,6 +170,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -196,6 +202,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -209,6 +216,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -220,6 +228,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getUuid()
     {
         return $this->container['uuid'];
@@ -232,6 +241,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUuid($uuid)
     {
         $this->container['uuid'] = $uuid;
@@ -244,6 +254,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getBlockId()
     {
         return $this->container['blockId'];
@@ -256,6 +267,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setBlockId($blockId)
     {
         $this->container['blockId'] = $blockId;
@@ -268,6 +280,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDescription()
     {
         return $this->container['description'];
@@ -280,6 +293,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDescription($description)
     {
         $this->container['description'] = $description;
@@ -293,6 +307,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -305,6 +320,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -318,6 +334,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -334,6 +351,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -346,6 +364,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -356,6 +375,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -369,6 +389,7 @@ class TemplateDetailsResponseContentPlaceholders implements ModelInterface, Arra
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/TemplateDetailsResponseImages.php
+++ b/src/Model/TemplateDetailsResponseImages.php
@@ -80,6 +80,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -90,6 +91,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -135,6 +137,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -145,6 +148,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -155,6 +159,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -165,6 +170,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -196,6 +202,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -209,6 +216,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -220,6 +228,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -232,6 +241,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -244,6 +254,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getBlockUuid()
     {
         return $this->container['blockUuid'];
@@ -256,6 +267,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setBlockUuid($blockUuid)
     {
         $this->container['blockUuid'] = $blockUuid;
@@ -268,6 +280,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getUrls()
     {
         return $this->container['urls'];
@@ -280,6 +293,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUrls($urls)
     {
         $this->container['urls'] = $urls;
@@ -293,6 +307,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -305,6 +320,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -318,6 +334,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -334,6 +351,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -346,6 +364,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -356,6 +375,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -369,6 +389,7 @@ class TemplateDetailsResponseImages implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/TemplateDetailsResponsePreassignedPerson.php
+++ b/src/Model/TemplateDetailsResponsePreassignedPerson.php
@@ -82,6 +82,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -92,6 +93,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -140,6 +142,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -150,6 +153,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -160,6 +164,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -170,6 +175,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -202,6 +208,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -215,6 +222,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -226,6 +234,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getEmail()
     {
         return $this->container['email'];
@@ -238,6 +247,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setEmail($email)
     {
         $this->container['email'] = $email;
@@ -250,6 +260,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getType()
     {
         return $this->container['type'];
@@ -262,6 +273,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setType($type)
     {
         $this->container['type'] = $type;
@@ -274,6 +286,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getPlaceholderName()
     {
         return $this->container['placeholderName'];
@@ -286,6 +299,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setPlaceholderName($placeholderName)
     {
         $this->container['placeholderName'] = $placeholderName;
@@ -298,6 +312,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getPlaceholderSource()
     {
         return $this->container['placeholderSource'];
@@ -310,6 +325,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setPlaceholderSource($placeholderSource)
     {
         $this->container['placeholderSource'] = $placeholderSource;
@@ -323,6 +339,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -335,6 +352,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -348,6 +366,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -364,6 +383,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -376,6 +396,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -386,6 +407,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -399,6 +421,7 @@ class TemplateDetailsResponsePreassignedPerson implements ModelInterface, ArrayA
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/TemplateDetailsResponseRoles.php
+++ b/src/Model/TemplateDetailsResponseRoles.php
@@ -82,6 +82,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -92,6 +93,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -140,6 +142,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -150,6 +153,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -160,6 +164,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -170,6 +175,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -202,6 +208,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -215,6 +222,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -226,6 +234,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -238,6 +247,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -250,6 +260,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -262,6 +273,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -274,6 +286,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getSigningOrder()
     {
         return $this->container['signingOrder'];
@@ -286,6 +299,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setSigningOrder($signingOrder)
     {
         $this->container['signingOrder'] = $signingOrder;
@@ -298,6 +312,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return \PandaDoc\Client\Model\TemplateDetailsResponsePreassignedPerson|null
      */
+    #[\ReturnTypeWillChange]
     public function getPreassignedPerson()
     {
         return $this->container['preassignedPerson'];
@@ -310,6 +325,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setPreassignedPerson($preassignedPerson)
     {
         $this->container['preassignedPerson'] = $preassignedPerson;
@@ -323,6 +339,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -335,6 +352,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -348,6 +366,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -364,6 +383,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -376,6 +396,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -386,6 +407,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -399,6 +421,7 @@ class TemplateDetailsResponseRoles implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/TemplateDetailsResponseTokens.php
+++ b/src/Model/TemplateDetailsResponseTokens.php
@@ -78,6 +78,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -88,6 +89,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -130,6 +132,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -140,6 +143,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -150,6 +154,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -160,6 +165,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -190,6 +196,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -203,6 +210,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -214,6 +222,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -226,6 +235,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -238,6 +248,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getValue()
     {
         return $this->container['value'];
@@ -250,6 +261,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setValue($value)
     {
         $this->container['value'] = $value;
@@ -263,6 +275,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -275,6 +288,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -288,6 +302,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -304,6 +319,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -316,6 +332,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -326,6 +343,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -339,6 +357,7 @@ class TemplateDetailsResponseTokens implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/TemplateListResponse.php
+++ b/src/Model/TemplateListResponse.php
@@ -76,6 +76,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -86,6 +87,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -125,6 +127,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -135,6 +138,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -145,6 +149,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -155,6 +160,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -184,6 +190,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -197,6 +204,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -208,6 +216,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return \PandaDoc\Client\Model\TemplateListResponseResults[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getResults()
     {
         return $this->container['results'];
@@ -220,6 +229,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setResults($results)
     {
         $this->container['results'] = $results;
@@ -233,6 +243,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +256,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +270,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +287,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +300,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -296,6 +311,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -309,6 +325,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, \JsonSerializ
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/TemplateListResponseResults.php
+++ b/src/Model/TemplateListResponseResults.php
@@ -84,6 +84,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -94,6 +95,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -145,6 +147,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -155,6 +158,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -165,6 +169,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -175,6 +180,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -208,6 +214,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -221,6 +228,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -232,6 +240,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getId()
     {
         return $this->container['id'];
@@ -244,6 +253,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setId($id)
     {
         $this->container['id'] = $id;
@@ -256,6 +266,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -268,6 +279,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -280,6 +292,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateCreated()
     {
         return $this->container['dateCreated'];
@@ -292,6 +305,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateCreated($dateCreated)
     {
         $this->container['dateCreated'] = $dateCreated;
@@ -304,6 +318,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateModified()
     {
         return $this->container['dateModified'];
@@ -316,6 +331,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateModified($dateModified)
     {
         $this->container['dateModified'] = $dateModified;
@@ -328,6 +344,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getVersion()
     {
         return $this->container['version'];
@@ -340,6 +357,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setVersion($version)
     {
         $this->container['version'] = $version;
@@ -353,6 +371,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -365,6 +384,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -378,6 +398,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -394,6 +415,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -406,6 +428,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -416,6 +439,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -429,6 +453,7 @@ class TemplateListResponseResults implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/TemplatesFolderCreateRequest.php
+++ b/src/Model/TemplatesFolderCreateRequest.php
@@ -78,6 +78,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -88,6 +89,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -130,6 +132,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -140,6 +143,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -150,6 +154,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -160,6 +165,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -190,6 +196,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -206,6 +213,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -217,6 +225,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -229,6 +238,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -241,6 +251,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getParentUuid()
     {
         return $this->container['parentUuid'];
@@ -253,6 +264,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setParentUuid($parentUuid)
     {
         $this->container['parentUuid'] = $parentUuid;
@@ -266,6 +278,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -278,6 +291,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -291,6 +305,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -307,6 +322,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -319,6 +335,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -329,6 +346,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -342,6 +360,7 @@ class TemplatesFolderCreateRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/TemplatesFolderCreateResponse.php
+++ b/src/Model/TemplatesFolderCreateResponse.php
@@ -80,6 +80,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -90,6 +91,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -135,6 +137,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -145,6 +148,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -155,6 +159,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -165,6 +170,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -196,6 +202,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -209,6 +216,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -220,6 +228,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getUuid()
     {
         return $this->container['uuid'];
@@ -232,6 +241,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUuid($uuid)
     {
         $this->container['uuid'] = $uuid;
@@ -244,6 +254,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -256,6 +267,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -268,6 +280,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateCreated()
     {
         return $this->container['dateCreated'];
@@ -280,6 +293,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateCreated($dateCreated)
     {
         $this->container['dateCreated'] = $dateCreated;
@@ -293,6 +307,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -305,6 +320,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -318,6 +334,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -334,6 +351,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -346,6 +364,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -356,6 +375,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -369,6 +389,7 @@ class TemplatesFolderCreateResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/TemplatesFolderListResponse.php
+++ b/src/Model/TemplatesFolderListResponse.php
@@ -76,6 +76,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -86,6 +87,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -125,6 +127,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -135,6 +138,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -145,6 +149,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -155,6 +160,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -184,6 +190,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -197,6 +204,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -208,6 +216,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return \PandaDoc\Client\Model\TemplatesFolderListResponseResults[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getResults()
     {
         return $this->container['results'];
@@ -220,6 +229,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setResults($results)
     {
         $this->container['results'] = $results;
@@ -233,6 +243,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +256,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +270,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +287,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +300,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -296,6 +311,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -309,6 +325,7 @@ class TemplatesFolderListResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/TemplatesFolderListResponseResults.php
+++ b/src/Model/TemplatesFolderListResponseResults.php
@@ -84,6 +84,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -94,6 +95,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -145,6 +147,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -155,6 +158,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -165,6 +169,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -175,6 +180,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -208,6 +214,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -221,6 +228,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -232,6 +240,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getUuid()
     {
         return $this->container['uuid'];
@@ -244,6 +253,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUuid($uuid)
     {
         $this->container['uuid'] = $uuid;
@@ -256,6 +266,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -268,6 +279,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -280,6 +292,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateCreated()
     {
         return $this->container['dateCreated'];
@@ -292,6 +305,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateCreated($dateCreated)
     {
         $this->container['dateCreated'] = $dateCreated;
@@ -304,6 +318,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getHasFolders()
     {
         return $this->container['hasFolders'];
@@ -316,6 +331,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setHasFolders($hasFolders)
     {
         $this->container['hasFolders'] = $hasFolders;
@@ -328,6 +344,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getHasItems()
     {
         return $this->container['hasItems'];
@@ -340,6 +357,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setHasItems($hasItems)
     {
         $this->container['hasItems'] = $hasItems;
@@ -353,6 +371,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -365,6 +384,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -378,6 +398,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -394,6 +415,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -406,6 +428,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -416,6 +439,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -429,6 +453,7 @@ class TemplatesFolderListResponseResults implements ModelInterface, ArrayAccess,
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/TemplatesFolderRenameRequest.php
+++ b/src/Model/TemplatesFolderRenameRequest.php
@@ -76,6 +76,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -86,6 +87,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -125,6 +127,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -135,6 +138,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -145,6 +149,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -155,6 +160,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -184,6 +190,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -200,6 +207,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -211,6 +219,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -223,6 +232,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -236,6 +246,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -248,6 +259,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -261,6 +273,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -277,6 +290,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -289,6 +303,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -299,6 +314,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -312,6 +328,7 @@ class TemplatesFolderRenameRequest implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/TemplatesFolderRenameResponse.php
+++ b/src/Model/TemplatesFolderRenameResponse.php
@@ -80,6 +80,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -90,6 +91,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -135,6 +137,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -145,6 +148,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -155,6 +159,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -165,6 +170,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -196,6 +202,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -209,6 +216,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -220,6 +228,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getUuid()
     {
         return $this->container['uuid'];
@@ -232,6 +241,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUuid($uuid)
     {
         $this->container['uuid'] = $uuid;
@@ -244,6 +254,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -256,6 +267,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -268,6 +280,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getDateCreated()
     {
         return $this->container['dateCreated'];
@@ -280,6 +293,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDateCreated($dateCreated)
     {
         $this->container['dateCreated'] = $dateCreated;
@@ -293,6 +307,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -305,6 +320,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -318,6 +334,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -334,6 +351,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -346,6 +364,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -356,6 +375,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -369,6 +389,7 @@ class TemplatesFolderRenameResponse implements ModelInterface, ArrayAccess, \Jso
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/WebhookEventDetailsResponse.php
+++ b/src/Model/WebhookEventDetailsResponse.php
@@ -98,6 +98,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -108,6 +109,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -180,6 +182,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -190,6 +193,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -200,6 +204,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -210,6 +215,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -250,6 +256,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -263,6 +270,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -274,6 +282,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getUuid()
     {
         return $this->container['uuid'];
@@ -286,6 +295,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUuid($uuid)
     {
         $this->container['uuid'] = $uuid;
@@ -298,6 +308,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -310,6 +321,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -322,6 +334,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return \PandaDoc\Client\Model\WebhookEventTriggerEnum|null
      */
+    #[\ReturnTypeWillChange]
     public function getType()
     {
         return $this->container['type'];
@@ -334,6 +347,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setType($type)
     {
         $this->container['type'] = $type;
@@ -346,6 +360,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return int|null
      */
+    #[\ReturnTypeWillChange]
     public function getHttpStatusCode()
     {
         return $this->container['httpStatusCode'];
@@ -358,6 +373,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setHttpStatusCode($httpStatusCode)
     {
         $this->container['httpStatusCode'] = $httpStatusCode;
@@ -370,6 +386,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return \PandaDoc\Client\Model\WebhookEventErrorEnum|null
      */
+    #[\ReturnTypeWillChange]
     public function getError()
     {
         return $this->container['error'];
@@ -382,6 +399,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setError($error)
     {
         $this->container['error'] = $error;
@@ -394,6 +412,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return \DateTime|null
      */
+    #[\ReturnTypeWillChange]
     public function getDeliveryTime()
     {
         return $this->container['deliveryTime'];
@@ -406,6 +425,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDeliveryTime($deliveryTime)
     {
         $this->container['deliveryTime'] = $deliveryTime;
@@ -418,6 +438,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getUrl()
     {
         return $this->container['url'];
@@ -430,6 +451,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUrl($url)
     {
         $this->container['url'] = $url;
@@ -442,6 +464,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getSignature()
     {
         return $this->container['signature'];
@@ -454,6 +477,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setSignature($signature)
     {
         $this->container['signature'] = $signature;
@@ -466,6 +490,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getRequestBody()
     {
         return $this->container['requestBody'];
@@ -478,6 +503,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setRequestBody($requestBody)
     {
         $this->container['requestBody'] = $requestBody;
@@ -490,6 +516,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getResponseBody()
     {
         return $this->container['responseBody'];
@@ -502,6 +529,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setResponseBody($responseBody)
     {
         $this->container['responseBody'] = $responseBody;
@@ -514,6 +542,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getResponseHeaders()
     {
         return $this->container['responseHeaders'];
@@ -526,6 +555,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setResponseHeaders($responseHeaders)
     {
         $this->container['responseHeaders'] = $responseHeaders;
@@ -538,6 +568,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return \DateTime|null
      */
+    #[\ReturnTypeWillChange]
     public function getEventTime()
     {
         return $this->container['eventTime'];
@@ -550,6 +581,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setEventTime($eventTime)
     {
         $this->container['eventTime'] = $eventTime;
@@ -563,6 +595,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -575,6 +608,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -588,6 +622,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -604,6 +639,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -616,6 +652,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -626,6 +663,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -639,6 +677,7 @@ class WebhookEventDetailsResponse implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/WebhookEventErrorEnum.php
+++ b/src/Model/WebhookEventErrorEnum.php
@@ -52,6 +52,7 @@ class WebhookEventErrorEnum
      * Gets allowable values of the enum
      * @return string[]
      */
+    #[\ReturnTypeWillChange]
     public static function getAllowableEnumValues()
     {
         return [

--- a/src/Model/WebhookEventHttpStatusCodeGroupEnum.php
+++ b/src/Model/WebhookEventHttpStatusCodeGroupEnum.php
@@ -54,6 +54,7 @@ class WebhookEventHttpStatusCodeGroupEnum
      * Gets allowable values of the enum
      * @return string[]
      */
+    #[\ReturnTypeWillChange]
     public static function getAllowableEnumValues()
     {
         return [

--- a/src/Model/WebhookEventItemResponse.php
+++ b/src/Model/WebhookEventItemResponse.php
@@ -86,6 +86,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -96,6 +97,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -150,6 +152,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -160,6 +163,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -170,6 +174,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -180,6 +185,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -214,6 +220,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -227,6 +234,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -238,6 +246,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getUuid()
     {
         return $this->container['uuid'];
@@ -250,6 +259,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUuid($uuid)
     {
         $this->container['uuid'] = $uuid;
@@ -262,6 +272,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -274,6 +285,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -286,6 +298,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return \PandaDoc\Client\Model\WebhookEventTriggerEnum|null
      */
+    #[\ReturnTypeWillChange]
     public function getType()
     {
         return $this->container['type'];
@@ -298,6 +311,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setType($type)
     {
         $this->container['type'] = $type;
@@ -310,6 +324,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return int|null
      */
+    #[\ReturnTypeWillChange]
     public function getHttpStatusCode()
     {
         return $this->container['httpStatusCode'];
@@ -322,6 +337,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setHttpStatusCode($httpStatusCode)
     {
         $this->container['httpStatusCode'] = $httpStatusCode;
@@ -334,6 +350,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return \PandaDoc\Client\Model\WebhookEventErrorEnum|null
      */
+    #[\ReturnTypeWillChange]
     public function getError()
     {
         return $this->container['error'];
@@ -346,6 +363,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setError($error)
     {
         $this->container['error'] = $error;
@@ -358,6 +376,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return \DateTime|null
      */
+    #[\ReturnTypeWillChange]
     public function getDeliveryTime()
     {
         return $this->container['deliveryTime'];
@@ -370,6 +389,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setDeliveryTime($deliveryTime)
     {
         $this->container['deliveryTime'] = $deliveryTime;
@@ -383,6 +403,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -395,6 +416,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -408,6 +430,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -424,6 +447,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -436,6 +460,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -446,6 +471,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -459,6 +485,7 @@ class WebhookEventItemResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/WebhookEventPageResponse.php
+++ b/src/Model/WebhookEventPageResponse.php
@@ -76,6 +76,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -86,6 +87,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -125,6 +127,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -135,6 +138,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -145,6 +149,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -155,6 +160,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -184,6 +190,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -197,6 +204,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -208,6 +216,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return \PandaDoc\Client\Model\WebhookEventItemResponse[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getItems()
     {
         return $this->container['items'];
@@ -220,6 +229,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setItems($items)
     {
         $this->container['items'] = $items;
@@ -233,6 +243,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +256,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +270,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +287,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +300,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -296,6 +311,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -309,6 +325,7 @@ class WebhookEventPageResponse implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/WebhookEventTriggerEnum.php
+++ b/src/Model/WebhookEventTriggerEnum.php
@@ -54,6 +54,7 @@ class WebhookEventTriggerEnum
      * Gets allowable values of the enum
      * @return string[]
      */
+    #[\ReturnTypeWillChange]
     public static function getAllowableEnumValues()
     {
         return [

--- a/src/Model/WebhookSubscriptionCreateRequest.php
+++ b/src/Model/WebhookSubscriptionCreateRequest.php
@@ -82,6 +82,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -92,6 +93,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -140,6 +142,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -150,6 +153,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -160,6 +164,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -170,6 +175,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -202,6 +208,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -224,6 +231,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -235,6 +243,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -247,6 +256,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -259,6 +269,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getUrl()
     {
         return $this->container['url'];
@@ -271,6 +282,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUrl($url)
     {
         $this->container['url'] = $url;
@@ -283,6 +295,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return \PandaDoc\Client\Model\WebhookSubscriptionPayloadEnum[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getPayload()
     {
         return $this->container['payload'];
@@ -295,6 +308,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setPayload($payload)
     {
         $this->container['payload'] = $payload;
@@ -307,6 +321,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return \PandaDoc\Client\Model\WebhookSubscriptionTriggerEnum[]
      */
+    #[\ReturnTypeWillChange]
     public function getTriggers()
     {
         return $this->container['triggers'];
@@ -319,6 +334,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTriggers($triggers)
     {
         $this->container['triggers'] = $triggers;
@@ -332,6 +348,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -344,6 +361,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -357,6 +375,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -373,6 +392,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -385,6 +405,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -395,6 +416,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -408,6 +430,7 @@ class WebhookSubscriptionCreateRequest implements ModelInterface, ArrayAccess, \
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/WebhookSubscriptionItemResponse.php
+++ b/src/Model/WebhookSubscriptionItemResponse.php
@@ -92,6 +92,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -102,6 +103,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -165,6 +167,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -175,6 +178,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -185,6 +189,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -195,6 +200,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -232,6 +238,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -245,6 +252,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -256,6 +264,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getUuid()
     {
         return $this->container['uuid'];
@@ -268,6 +277,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUuid($uuid)
     {
         $this->container['uuid'] = $uuid;
@@ -280,6 +290,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -292,6 +303,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -304,6 +316,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getUrl()
     {
         return $this->container['url'];
@@ -316,6 +329,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUrl($url)
     {
         $this->container['url'] = $url;
@@ -328,6 +342,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getActive()
     {
         return $this->container['active'];
@@ -340,6 +355,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setActive($active)
     {
         $this->container['active'] = $active;
@@ -352,6 +368,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return \PandaDoc\Client\Model\WebhookSubscriptionPayloadEnum[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getPayload()
     {
         return $this->container['payload'];
@@ -364,6 +381,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setPayload($payload)
     {
         $this->container['payload'] = $payload;
@@ -376,6 +394,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return \PandaDoc\Client\Model\WebhookSubscriptionTriggerEnum[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getTriggers()
     {
         return $this->container['triggers'];
@@ -388,6 +407,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTriggers($triggers)
     {
         $this->container['triggers'] = $triggers;
@@ -400,6 +420,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getWorkspaceId()
     {
         return $this->container['workspaceId'];
@@ -412,6 +433,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setWorkspaceId($workspaceId)
     {
         $this->container['workspaceId'] = $workspaceId;
@@ -424,6 +446,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getSharedKey()
     {
         return $this->container['sharedKey'];
@@ -436,6 +459,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setSharedKey($sharedKey)
     {
         $this->container['sharedKey'] = $sharedKey;
@@ -448,6 +472,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return \PandaDoc\Client\Model\WebhookSubscriptionStatusEnum|null
      */
+    #[\ReturnTypeWillChange]
     public function getStatus()
     {
         return $this->container['status'];
@@ -460,6 +485,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setStatus($status)
     {
         $this->container['status'] = $status;
@@ -473,6 +499,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -485,6 +512,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -498,6 +526,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -514,6 +543,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -526,6 +556,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -536,6 +567,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -549,6 +581,7 @@ class WebhookSubscriptionItemResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/WebhookSubscriptionListResponse.php
+++ b/src/Model/WebhookSubscriptionListResponse.php
@@ -76,6 +76,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -86,6 +87,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -125,6 +127,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -135,6 +138,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -145,6 +149,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -155,6 +160,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -184,6 +190,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -197,6 +204,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -208,6 +216,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return \PandaDoc\Client\Model\WebhookSubscriptionItemResponse[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getItems()
     {
         return $this->container['items'];
@@ -220,6 +229,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setItems($items)
     {
         $this->container['items'] = $items;
@@ -233,6 +243,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +256,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +270,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +287,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +300,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -296,6 +311,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -309,6 +325,7 @@ class WebhookSubscriptionListResponse implements ModelInterface, ArrayAccess, \J
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/WebhookSubscriptionPatchRequest.php
+++ b/src/Model/WebhookSubscriptionPatchRequest.php
@@ -84,6 +84,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -94,6 +95,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -145,6 +147,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -155,6 +158,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -165,6 +169,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -175,6 +180,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -208,6 +214,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -221,6 +228,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -232,6 +240,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getName()
     {
         return $this->container['name'];
@@ -244,6 +253,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setName($name)
     {
         $this->container['name'] = $name;
@@ -256,6 +266,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getUrl()
     {
         return $this->container['url'];
@@ -268,6 +279,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setUrl($url)
     {
         $this->container['url'] = $url;
@@ -280,6 +292,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return bool|null
      */
+    #[\ReturnTypeWillChange]
     public function getActive()
     {
         return $this->container['active'];
@@ -292,6 +305,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setActive($active)
     {
         $this->container['active'] = $active;
@@ -304,6 +318,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return \PandaDoc\Client\Model\WebhookSubscriptionPayloadEnum[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getPayload()
     {
         return $this->container['payload'];
@@ -316,6 +331,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setPayload($payload)
     {
         $this->container['payload'] = $payload;
@@ -328,6 +344,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return \PandaDoc\Client\Model\WebhookSubscriptionTriggerEnum[]|null
      */
+    #[\ReturnTypeWillChange]
     public function getTriggers()
     {
         return $this->container['triggers'];
@@ -340,6 +357,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setTriggers($triggers)
     {
         $this->container['triggers'] = $triggers;
@@ -353,6 +371,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -365,6 +384,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -378,6 +398,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -394,6 +415,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -406,6 +428,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -416,6 +439,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -429,6 +453,7 @@ class WebhookSubscriptionPatchRequest implements ModelInterface, ArrayAccess, \J
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/WebhookSubscriptionPayloadEnum.php
+++ b/src/Model/WebhookSubscriptionPayloadEnum.php
@@ -54,6 +54,7 @@ class WebhookSubscriptionPayloadEnum
      * Gets allowable values of the enum
      * @return string[]
      */
+    #[\ReturnTypeWillChange]
     public static function getAllowableEnumValues()
     {
         return [

--- a/src/Model/WebhookSubscriptionSharedKeyResponse.php
+++ b/src/Model/WebhookSubscriptionSharedKeyResponse.php
@@ -76,6 +76,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPITypes()
     {
         return self::$openAPITypes;
@@ -86,6 +87,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function openAPIFormats()
     {
         return self::$openAPIFormats;
@@ -125,6 +127,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function attributeMap()
     {
         return self::$attributeMap;
@@ -135,6 +138,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function setters()
     {
         return self::$setters;
@@ -145,6 +149,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public static function getters()
     {
         return self::$getters;
@@ -155,6 +160,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function getModelName()
     {
         return self::$openAPIModelName;
@@ -184,6 +190,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      *
      * @return array invalid properties with reasons
      */
+    #[\ReturnTypeWillChange]
     public function listInvalidProperties()
     {
         $invalidProperties = [];
@@ -197,6 +204,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      *
      * @return bool True if all properties are valid
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return count($this->listInvalidProperties()) === 0;
@@ -208,6 +216,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      *
      * @return string|null
      */
+    #[\ReturnTypeWillChange]
     public function getSharedKey()
     {
         return $this->container['sharedKey'];
@@ -220,6 +229,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      *
      * @return self
      */
+    #[\ReturnTypeWillChange]
     public function setSharedKey($sharedKey)
     {
         $this->container['sharedKey'] = $sharedKey;
@@ -233,6 +243,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -245,6 +256,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -258,6 +270,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -274,6 +287,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -286,6 +300,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);
@@ -296,6 +311,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return json_encode(
@@ -309,6 +325,7 @@ class WebhookSubscriptionSharedKeyResponse implements ModelInterface, ArrayAcces
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function toHeaderValue()
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));

--- a/src/Model/WebhookSubscriptionStatusEnum.php
+++ b/src/Model/WebhookSubscriptionStatusEnum.php
@@ -50,6 +50,7 @@ class WebhookSubscriptionStatusEnum
      * Gets allowable values of the enum
      * @return string[]
      */
+    #[\ReturnTypeWillChange]
     public static function getAllowableEnumValues()
     {
         return [

--- a/src/Model/WebhookSubscriptionTriggerEnum.php
+++ b/src/Model/WebhookSubscriptionTriggerEnum.php
@@ -54,6 +54,7 @@ class WebhookSubscriptionTriggerEnum
      * Gets allowable values of the enum
      * @return string[]
      */
+    #[\ReturnTypeWillChange]
     public static function getAllowableEnumValues()
     {
         return [

--- a/src/ObjectSerializer.php
+++ b/src/ObjectSerializer.php
@@ -60,6 +60,7 @@ class ObjectSerializer
      *
      * @return scalar|object|array|null serialized form of $data
      */
+    #[\ReturnTypeWillChange]
     public static function sanitizeForSerialization($data, $type = null, $format = null)
     {
         if (is_scalar($data) || null === $data) {
@@ -118,6 +119,7 @@ class ObjectSerializer
      *
      * @return string the sanitized filename
      */
+    #[\ReturnTypeWillChange]
     public static function sanitizeFilename($filename)
     {
         if (preg_match("/.*[\/\\\\](.*)$/", $filename, $match)) {
@@ -134,6 +136,7 @@ class ObjectSerializer
      *
      * @return string the shorten timestamp
      */
+    #[\ReturnTypeWillChange]
     public static function sanitizeTimestamp($timestamp)
     {
         if (!is_string($timestamp)) return $timestamp;
@@ -149,6 +152,7 @@ class ObjectSerializer
      *
      * @return string the serialized object
      */
+    #[\ReturnTypeWillChange]
     public static function toPathValue($value)
     {
         return rawurlencode(self::toString($value));
@@ -164,6 +168,7 @@ class ObjectSerializer
      *
      * @return string the serialized object
      */
+    #[\ReturnTypeWillChange]
     public static function toQueryValue($object)
     {
         if (is_array($object)) {
@@ -182,6 +187,7 @@ class ObjectSerializer
      *
      * @return string the header string
      */
+    #[\ReturnTypeWillChange]
     public static function toHeaderValue($value)
     {
         $callable = [$value, 'toHeaderValue'];
@@ -201,6 +207,7 @@ class ObjectSerializer
      *
      * @return string the form string
      */
+    #[\ReturnTypeWillChange]
     public static function toFormValue($value)
     {
         if ($value instanceof \SplFileObject) {
@@ -220,6 +227,7 @@ class ObjectSerializer
      *
      * @return string the header string
      */
+    #[\ReturnTypeWillChange]
     public static function toString($value)
     {
         if ($value instanceof \DateTime) { // datetime in ISO8601 format
@@ -241,6 +249,7 @@ class ObjectSerializer
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public static function serializeCollection(array $collection, $style, $allowCollectionFormatMulti = false)
     {
         if ($allowCollectionFormatMulti && ('multi' === $style)) {
@@ -278,6 +287,7 @@ class ObjectSerializer
      *
      * @return object|array|null a single or an array of $class instances
      */
+    #[\ReturnTypeWillChange]
     public static function deserialize($data, $class, $httpHeaders = null)
     {
         if (null === $data) {


### PR DESCRIPTION
- Suppress deprecated warnings in PHP 8.1. Added attribute which signals that a mismatching tentative return type should not emit a deprecation notice